### PR TITLE
Highlight selected line in target window.

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -113,6 +113,11 @@ func! ctrlsf#CloseWindow() abort
     call s:CloseWindow()
 endf
 " }}}
+" ctrlsf#ClearHighlight() {{{2
+func! ctrlsf#ClearHighlight() abort
+    call s:ClearHighlight()
+endf
+" }}}
 " }}}
 
 " Actions {{{1
@@ -156,6 +161,12 @@ func! s:CloseWindow()
     close
 
     call s:FocusPreviousWindow()
+endf
+" }}}
+
+" s:ClearHighlight() {{{2
+func! s:ClearHighlight()
+    match none
 endf
 " }}}
 
@@ -287,8 +298,9 @@ func! s:OpenTargetWindow(winnr, file, lnum, col)
     call cursor(a:lnum, a:col)
     " From
     " http://vim.wikia.com/wiki/Highlight_current_line#Highlighting_that_stays_after_cursor_moves
-    mark l
-    exec 'match Search /\%' . line('.') . 'l.*/'
+    if g:ctrlsf_current_line_hl
+        exec 'match Search /\%' . line('.') . 'l.*/'
+    endif
 
     normal zv
 endf

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -109,8 +109,12 @@ A typical workflow using CtrlSF is like this:
 
 :CtrlSFClose                                                    *:CtrlSFClose*
 
-  Close a existing CtrlSF window. If there is no active CtrlSF window, do
+  Close an existing CtrlSF window. If there is no active CtrlSF window, do
   nothing.
+
+:CtrlSFClearHighlight                                  *:CtrlSFClearHighlight*
+  If you are using |g:ctrlsf_current_line_hl|, you can use this command to
+  clear the highlight on the selected line.
 
 ==============================================================================
 4. Key Maps                                                   *ctrlsf-keymaps*
@@ -172,6 +176,13 @@ of argument:
 Example:
 >
     let g:ctrlsf_width = '30%'
+
+g:ctrlsf_current_line_hl                          *'g:ctrlsf_current_line_hl'*
+Default: 0
+If you want highlight what you selected line in CtrlSF window in the target
+window:
+>
+    let g:ctrlsf_current_line_hl = 1
 <
 ==============================================================================
 6. About                                                        *ctrlsf-about*

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -51,12 +51,25 @@ endif
 if !exists('g:ctrlsf_width')
     let g:ctrlsf_width = 'auto'
 endif
+
+if !exists('g:ctrlsf_current_line_hl')
+    let g:ctrlsf_current_line_hl = 0
+endif
+
+if !exists('g:ctrlsf_current_line_mark')
+    let g:ctrlsf_current_line_mark = 0
+endif
+
+if !exists('g:ctrlsf_current_line_mark_reg')
+    let g:ctrlsf_current_line_mark_reg = 'l'
+endif
 " }}}
 
 " Commands {{{1
-com! -n=* -comp=customlist,s:PathnameComp CtrlSF      call ctrlsf#Search(<q-args>)
-com! -n=0                                 CtrlSFOpen  call ctrlsf#OpenWindow()
-com! -n=0                                 CtrlSFClose call ctrlsf#CloseWindow()
+com! -n=* -comp=customlist,s:PathnameComp CtrlSF               call ctrlsf#Search(<q-args>)
+com! -n=0                                 CtrlSFOpen           call ctrlsf#OpenWindow()
+com! -n=0                                 CtrlSFClose          call ctrlsf#CloseWindow()
+com! -n=0                                 CtrlSFClearHighlight call ctrlsf#ClearHighlight()
 " }}}
 
 " Completion Func {{{1


### PR DESCRIPTION
Also add a mark `l` for that line, so you can go back there with `'l`.

这样一来 CtrlSF 利用度更高一些，能够记忆刚开始在 CtrlSF 中选择的行，虽然高亮会被其他搜索 `hlsearch` 覆盖掉。
