### PR TITLE
Highlight matching case insensitively for ag

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -516,8 +516,12 @@ func! s:HighlightMatch() abort
         return -2
     endif
 
-    let case    = get(s:ackprg_options, 'ignorecase') ? '\c' : ''
+    let case = ''
+    if (g:ctrlsf_ackprg == 'ag' || get(s:ackprg_options, 'ignorecase'))
+        let case = '\c'
+    endif
     let pattern = printf('/\v%s%s/', case, escape(s:ackprg_options['pattern'], '/'))
+
     exec 'match ctrlsfMatch ' . pattern
 endf
 " }}}


### PR DESCRIPTION
Fix issue #19.

By default, `ag` matches text case-insensitively. ctrlsf should have the same behavior.
