### PR TITLE
Support for horizontal splits.

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -220,7 +220,6 @@ func! s:OpenWindow() abort
             endif
         endif
 
-        " let openpos = g:ctrlsf_open_left ? 'topleft vertical ' : 'botright vertical '
         let openpos = {
               \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
               \ 'bottom' : 'botright', 'right' : 'botright vertical'}
@@ -360,10 +359,9 @@ func! s:OpenPreviewWindow() abort
         let winsize = min([&lines-ctrlsf_height, ctrlsf_height])
     endif
 
-    " let openpos = g:ctrlsf_open_left ? 'rightbelow vertical ' : 'leftabove vertical '
     let openpos = {
             \ 'bottom': 'leftabove',       'right'  : 'leftabove vertical',
-            \ 'top'   : 'rightabove',       'left' : 'rightbelow vertical'}
+            \ 'top'   : 'rightbelow',       'left' : 'rightbelow vertical'}
             \[g:ctrlsf_position] . ' '
     exec 'silent keepalt ' . openpos . winsize . 'split ' . '__CtrlSFPreview__'
 

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -204,16 +204,28 @@ func! s:OpenWindow() abort
     " focus an existing ctrlsf window
     " if failed, initialize a new one
     if s:FocusCtrlsfWindow() == -1
-        if g:ctrlsf_width =~ '\d\{1,2}%'
-            let width = &columns * str2nr(g:ctrlsf_width) / 100
-        elseif g:ctrlsf_width =~ '\d\+'
-            let width = str2nr(g:ctrlsf_width)
+        if g:ctrlsf_winsize =~ '\d\{1,2}%'
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+                let winsize = &columns * str2nr(g:ctrlsf_winsize) / 100
+            else
+                let winsize = &lines * str2nr(g:ctrlsf_winsize) / 100
+            endif
+        elseif g:ctrlsf_winsize =~ '\d\+'
+            let winsize = str2nr(g:ctrlsf_winsize)
         else
-            let width = &columns / 2
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+                let winsize = &columns / 2
+            else
+                let winsize = &lines / 2
+            endif
         endif
 
-        let openpos = g:ctrlsf_open_left ? 'topleft vertical ' : 'botright vertical '
-        exec 'silent keepalt ' . openpos . width . 'split ' . '__CtrlSF__'
+        " let openpos = g:ctrlsf_open_left ? 'topleft vertical ' : 'botright vertical '
+        let openpos = {
+              \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
+              \ 'bottom' : 'botright', 'right' : 'botright vertical'}
+              \[g:ctrlsf_position] . ' '
+        exec 'silent keepalt ' . openpos . winsize . 'split ' . '__CtrlSF__'
 
         call s:InitWindow()
     endif
@@ -340,11 +352,20 @@ endf
 
 " s:OpenPreviewWindow() {{{2
 func! s:OpenPreviewWindow() abort
-    let ctrlsf_width  = winwidth(0)
-    let width = min([&columns-ctrlsf_width, ctrlsf_width])
+    if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+        let ctrlsf_width  = winwidth(0)
+        let winsize = min([&columns-ctrlsf_width, ctrlsf_width])
+    else
+        let ctrlsf_height  = winheight(0)
+        let winsize = min([&lines-ctrlsf_height, ctrlsf_height])
+    endif
 
-    let openpos = g:ctrlsf_open_left ? 'rightbelow vertical ' : 'leftabove vertical '
-    exec 'silent keepalt ' . openpos . width . 'split ' . '__CtrlSFPreview__'
+    " let openpos = g:ctrlsf_open_left ? 'rightbelow vertical ' : 'leftabove vertical '
+    let openpos = {
+            \ 'bottom': 'leftabove',       'right'  : 'leftabove vertical',
+            \ 'top'   : 'rightabove',       'left' : 'rightbelow vertical'}
+            \[g:ctrlsf_position] . ' '
+    exec 'silent keepalt ' . openpos . winsize . 'split ' . '__CtrlSFPreview__'
 
     setl buftype=nofile
     setl bufhidden=hide

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -204,11 +204,12 @@ Example:
 >
     let g:ctrlsf_leading_space = 8
 <
-g:ctrlsf_open_left
-Default: '1'
-By default CtrlSF window will be opened at left, change it to right by
+g:ctrlsf_position
+Default: 'left'
+By default CtrlSF window will be opened at left. You can also specify for it to
+be opened 'above', 'right', or 'below'. E.g.:
 >
-    let g:ctrlsf_open_left = 0
+    let g:ctrlsf_position = 'below'
 <
 g:ctrlsf_selected_line_hl                        *'g:ctrlsf_selected_line_hl'*
 Default: 'p'
@@ -224,10 +225,11 @@ can config it as
 >
     let g:ctrlsf_selected_line_hl = 'op'
 <
-g:ctrlsf_width                                              *'g:ctrlsf_width'*
+g:ctrlsf_winsize                                              *'g:ctrlsf_width'*
 Default: 'auto'
-Width of CtrlSF window. It accepts string as its value and there are 3 types
-of argument:
+Size of CtrlSF window. This is its width if the window opens vertically (to the
+left or right), or height if it opens horizontally (above or below). It accepts
+string as its value and there are 3 types of argument:
 >
     'auto' : half of current vim window size.
     'xx%'  : xx percent of current vim window size.
@@ -235,7 +237,7 @@ of argument:
 <
 Example:
 >
-    let g:ctrlsf_width = '30%'
+    let g:ctrlsf_winsize = '30%'
 
 ==============================================================================
 6. About                                                        *ctrlsf-about*

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -76,8 +76,16 @@ endf
 " }}}
 
 " Options {{{1
-if !exists('g:ctrlsf_open_left')
-    let g:ctrlsf_open_left = 1
+if !exists('g:ctrlsf_position')
+    " [left], right, top, bottom
+    if exists('g:ctrlsf_open_left')
+        if g:ctrlsf_open_left = 1
+            let g:ctrlsf_position = 'left'
+        else
+            let g:ctrlsf_position = 'right'
+        endif
+    endif
+    let g:ctrlsf_position = 'left'
 endif
 
 if !exists('g:ctrlsf_ackprg')
@@ -92,8 +100,11 @@ if !exists('g:ctrlsf_context')
     let g:ctrlsf_context = '-C 3'
 endif
 
-if !exists('g:ctrlsf_width')
-    let g:ctrlsf_width = 'auto'
+if !exists('g:ctrlsf_winsize')
+    if exists('g:ctrlsf_open_width')
+        let g:ctrlsf_winsize = g:ctrlsf_open_width
+    endif
+    let g:ctrlsf_winsize = 'auto'
 endif
 
 if !exists('g:ctrlsf_selected_line_hl')

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -101,8 +101,8 @@ if !exists('g:ctrlsf_context')
 endif
 
 if !exists('g:ctrlsf_winsize')
-    if exists('g:ctrlsf_open_width')
-        let g:ctrlsf_winsize = g:ctrlsf_open_width
+    if exists('g:ctrlsf_width')
+        let g:ctrlsf_winsize = g:ctrlsf_width
     endif
     let g:ctrlsf_winsize = 'auto'
 endif


### PR DESCRIPTION
*   Use `g:ctrlsf_position` to specify one of `left`, `right`, `top`, or
   `bottom`.
*   Use `g:ctrlsf_winsize` to specify size