### PR TITLE
set winfixheight for main and preview window

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -371,6 +371,7 @@ func! s:OpenPreviewWindow() abort
     setl nobuflisted
     setl nomodifiable
     setl winfixwidth
+    setl winfixheight
 
     map q :call <SID>ClosePreviewWindow()<CR>
 endf
@@ -420,6 +421,7 @@ func! s:InitWindow() abort
     setl nonumber
     setl nowrap
     setl winfixwidth
+    setl winfixheight
     setl textwidth=0
     setl nospell
     setl nofoldenable


### PR DESCRIPTION
if winfixheight is not set, ':wincmd =' will equallize heights of all
windows. This makes 'g:ctrlsf_winsize` not works as expected when window
is splitted horizontally.