### PR TITLE
Return empty as default value of argument

### DIFF
--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -59,7 +59,7 @@ func! ctrlsf#opt#GetOpt(name) abort
     if has_key(s:options, a:name)
         return s:options[a:name]
     else
-        return s:default[a:name]
+        return get(s:default, 'a:name', '')
     endif
 endf
 


### PR DESCRIPTION
Main goal of this commit is to fix error in :CtrlSFOpen for fresh opened vim where no search has ever been invoked.