### PR TITLE
v1.5

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -279,3 +279,15 @@ endf
 func! ctrlsf#ClearSelectedLine() abort
     call ctrlsf#hl#ClearSelectedLine()
 endf
+
+" ToggleMap()
+"
+func! ctrlsf#ToggleMap() abort
+    call ctrlsf#buf#ToggleMap()
+
+    if b:ctrlsf_map_enabled
+        echo "Maps enabled."
+    else
+        echo "Maps disabled."
+    endif
+endf

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -38,6 +38,12 @@ func! s:BuildCommand(args) abort
     endif
     call add(tokens, case)
 
+    " ignore (dir, file)
+    let ignore_dir = ctrlsf#opt#GetIgnoreDir()
+    for dir in ignore_dir
+        call add(tokens, "--ignore-dir " . dir)
+    endfor
+
     " regex
     if !ctrlsf#opt#GetRegex()
         call add(tokens, '--literal')

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -53,3 +53,43 @@ func! ctrlsf#buf#UndoAllChanges() abort
     endif
 endf
 
+" ToogleMap()
+"
+" Enable/disable maps in CtrlSF window.
+"
+" There are 3 possible values of argument:
+"
+"   - 0    : disable
+"   - 1    : enable
+"   - None : toggle
+"
+func! ctrlsf#buf#ToggleMap(...) abort
+    if a:0 > 0
+        let enable_map = a:1
+    else
+        let enable_map = !b:ctrlsf_map_enabled
+    endif
+
+    " key 'prevw' is a deprecated key but here for backward compatibility
+    let act_func_ref = {
+        \ "open"  : "ctrlsf#JumpTo('open')",
+        \ "openb" : "ctrlsf#JumpTo('open_background')",
+        \ "split" : "ctrlsf#JumpTo('split')",
+        \ "tab"   : "ctrlsf#JumpTo('tab')",
+        \ "tabb"  : "ctrlsf#JumpTo('tab_background')",
+        \ "prevw" : "ctrlsf#JumpTo('preview')",
+        \ "popen" : "ctrlsf#JumpTo('preview')",
+        \ "quit"  : "ctrlsf#Quit()",
+        \ "next"  : "ctrlsf#NextMatch(1)",
+        \ "prev"  : "ctrlsf#NextMatch(0)",
+        \ "llist" : "ctrlsf#OpenLocList()",
+        \ }
+
+    if enable_map
+        call ctrlsf#utils#Nmap(g:ctrlsf_mapping, act_func_ref)
+    else
+        call ctrlsf#utils#Nunmap(g:ctrlsf_mapping, act_func_ref)
+    endif
+
+    let b:ctrlsf_map_enabled = enable_map
+endf

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -13,6 +13,7 @@ let s:option_list = {
     \ '-filetype'   : {'args': 1},
     \ '-filematch'  : {'args': 1},
     \ '-ignorecase' : {'args': 0},
+    \ '-ignoredir'  : {'args': 1},
     \ '-literal'    : {'args': 0},
     \ '-matchcase'  : {'args': 0},
     \ '-regex'      : {'args': 0},
@@ -170,6 +171,12 @@ func! ctrlsf#opt#GetRegex() abort
     else
         return g:ctrlsf_regex_pattern
     endif
+endf
+
+" GetIgnoreDir()
+"
+func! ctrlsf#opt#GetIgnoreDir() abort
+    return add(copy(g:ctrlsf_ignore_dir), ctrlsf#opt#GetOpt("ignoredir"))
 endf
 
 """""""""""""""""""""""""""""""""

--- a/autoload/ctrlsf/preview.vim
+++ b/autoload/ctrlsf/preview.vim
@@ -65,7 +65,7 @@ func! s:InitPreviewWindow() abort
     let act_func_ref = {
         \ "pquit": "ctrlsf#preview#ClosePreviewWindow()"
         \ }
-    call ctrlsf#utils#SetMap(g:ctrlsf_mapping, act_func_ref)
+    call ctrlsf#utils#Nmap(g:ctrlsf_mapping, act_func_ref)
 
     augroup ctrlsfp
         au!

--- a/autoload/ctrlsf/utils.vim
+++ b/autoload/ctrlsf/utils.vim
@@ -24,23 +24,43 @@ func! ctrlsf#utils#Mirror(dicta, dictb) abort
     return a:dicta
 endf
 
-" SetMap()
+" Nmap()
 "
-func! ctrlsf#utils#SetMap(map, act_func_ref) abort
+func! ctrlsf#utils#Nmap(map, act_func_ref) abort
     for act in keys(a:act_func_ref)
         if empty(get(a:map, act, ""))
             continue
         endif
 
         if type(a:map[act]) == 1
-            exec "nnoremap <silent><buffer> " . a:map[act]
+            exec "silent! nnoremap <silent><buffer> " . a:map[act]
                 \ . " :call " . a:act_func_ref[act] . "<CR>"
         endif
 
         if type(a:map[act]) == 3
             for key in a:map[act]
-                exec "nnoremap <silent><buffer> " . key
+                exec "silent! nnoremap <silent><buffer> " . key
                     \ . " :call " . a:act_func_ref[act] . "<CR>"
+            endfo
+        endif
+    endfo
+endf
+
+" Nunmap()
+"
+func! ctrlsf#utils#Nunmap(map, act_func_ref) abort
+    for act in keys(a:act_func_ref)
+        if empty(get(a:map, act, ""))
+            continue
+        endif
+
+        if type(a:map[act]) == 1
+            exec "nunmap <silent><buffer> " . a:map[act]
+        endif
+
+        if type(a:map[act]) == 3
+            for key in a:map[act]
+                exec "nunmap <silent><buffer> " . key
             endfo
         endif
     endfo

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -61,7 +61,7 @@ func! ctrlsf#win#OpenMainWindow() abort
     call s:InitMainWindow()
 
     " resize other windows
-    wincmd =
+    call s:ResizeNeighborWins()
 endf
 
 " Draw()
@@ -87,8 +87,21 @@ func! ctrlsf#win#CloseMainWindow() abort
     call ctrlsf#win#FocusCallerWindow()
 endf
 
+" ResizeNeighborWins()
+"
+func! s:ResizeNeighborWins() abort
+    setl winfixwidth
+    setl winfixheight
+    wincmd =
+endf
+
 " InitMainWindow()
 func! s:InitMainWindow() abort
+    if exists("b:ctrlsf_initialized")
+        return
+    endif
+
+    " option
     setl filetype=ctrlsf
     setl fileformat=unix
     setl fileencoding=utf-8
@@ -108,21 +121,15 @@ func! s:InitMainWindow() abort
     setl nofoldenable
 
     " map
-    " key 'prevw' is a deprecated key but here for backward compatibility
-    let act_func_ref = {
-        \ "open"  : "ctrlsf#JumpTo('open')",
-        \ "openb" : "ctrlsf#JumpTo('open_background')",
-        \ "split" : "ctrlsf#JumpTo('split')",
-        \ "tab"   : "ctrlsf#JumpTo('tab')",
-        \ "tabb"  : "ctrlsf#JumpTo('tab_background')",
-        \ "prevw" : "ctrlsf#JumpTo('preview')",
-        \ "popen" : "ctrlsf#JumpTo('preview')",
-        \ "quit"  : "ctrlsf#Quit()",
-        \ "next"  : "ctrlsf#NextMatch(1)",
-        \ "prev"  : "ctrlsf#NextMatch(0)",
-        \ "llist" : "ctrlsf#OpenLocList()",
-        \ }
-    call ctrlsf#utils#SetMap(g:ctrlsf_mapping, act_func_ref)
+    call ctrlsf#buf#ToggleMap(1)
+
+    if !empty(g:ctrlsf_toggle_map_key)
+        exec 'nnoremap <silent><buffer> ' . g:ctrlsf_toggle_map_key
+            \ ' :CtrlSFToggleMap<CR>'
+    endif
+
+    " cmd
+    command! -buffer CtrlSFToggleMap call ctrlsf#ToggleMap()
 
     " autocmd
     augroup ctrlsf
@@ -130,6 +137,8 @@ func! s:InitMainWindow() abort
         au BufWriteCmd         <buffer> call ctrlsf#Save()
         au BufHidden,BufUnload <buffer> call ctrlsf#buf#UndoAllChanges()
     augroup END
+
+    let b:ctrlsf_initialized = 1
 endf
 
 

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -168,6 +168,11 @@ mode:
 
   Open the CtrlSF window if it is closed, or vice versa.
 
+:CtrlSFToggleMap                                              *:CtrlSFToggleMap*
+
+  Toggle CtrlSF's default key mapping. This command can be used in CtrlSF
+  window only.
+
 ================================================================================
 4. Key Maps                                                     *ctrlsf-keymaps*
 
@@ -413,6 +418,14 @@ can set it as
 >
     let g:ctrlsf_selected_line_hl = 'op'
 <
+g:ctrlsf_toggle_map_key                                *'g:ctrlsf_toggle_map_key'*
+Default: ''
+Key to temporarily enable/disable CtrlSF's default key mapping. By default
+this value is empty, means no key is mapped for this feature.
+>
+    let g:ctrlsf_toggle_map_key = '\t'
+<
+
 g:ctrlsf_winsize                                                *'g:ctrlsf_width'*
 Default: 'auto'
 Size of CtrlSF window. This is its width if the window opens vertically (to the

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -242,7 +242,7 @@ alias for '-context'.
 >
     :CtrlSF -C 0 foo
 <
-'-filetype'                                               *ctrlsf_args_filetype*
+'-filetype'                                             *ctrlsf_args_filetype*
 
 Defines which type of files should the search be restricted to. view
 `ack --help=typs` for all available types.
@@ -260,6 +260,14 @@ Defines a pattern that only files whose name is matching will be searched.
 Make this search be case-insensitive.
 >
     :CtrlSF -I foo
+<
+'-ignoredir'                                           *ctrlsf_args_ignoredir*
+
+Defines pattern of directories that should be ignored. The behavior of this
+option depends on what backend you are using. The actual option used
+here is '--ignore' for ag and '--ignore-dir' for ack.
+>
+    :CtrlSF -ignoredir "bower_components" 'console.log'
 <
 '-literal', '-L'                           *ctrlsf_args_L* *ctrlsf_args_literal*
 
@@ -279,7 +287,7 @@ Use pattern as regular expression.
 >
     :CtrlSF -R foo.*
 <
-'-smartcase'                                             *ctrlsf_args_smartcase*
+'-smartcase'                                           *ctrlsf_args_smartcase*
 
 Make this search be smart-cased.
 >
@@ -343,6 +351,14 @@ placed in, currently CtrlSF can recognize .git, .hg, .svn, .bzr, _darcs.
 >
     let g:ctrlsf_default_root = 'project'
 <
+g:ctrlsf_ignore_dir                                      *'g:ctrlsf_ignore_dir'*
+Default: ''
+Defines directories that will be ignored by default. It's useful for backend
+that does not respect to '.gitignore'.
+>
+    let g:ctrlsf_ignore_dir = ['bower_components', 'npm_modules']
+<
+
 g:ctrlsf_indent                                              *'g:ctrlsf_indent'*
 Default: 4
 Defines how many spaces are placed between line number and line content. You

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -345,7 +345,7 @@ placed in, currently CtrlSF can recognize .git, .hg, .svn, .bzr, _darcs.
 <
 g:ctrlsf_indent                                              *'g:ctrlsf_indent'*
 Default: 4
-Defines how many spaces are places between line number and line content. You
+Defines how many spaces are placed between line number and line content. You
 can set a sane small value for more compact view.
 >
     let g:ctrlsf_indent = 2

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -180,6 +180,12 @@ if !exists('g:ctrlsf_selected_line_hl')
 endif
 " }}}
 
+" g:ctrlsf_toggle_map_key {{{2
+if !exists('g:ctrlsf_toggle_map_key')
+    let g:ctrlsf_toggle_map_key = ''
+endif
+" }}}
+
 " g:ctrlsf_winsize {{{2
 if !exists('g:ctrlsf_winsize')
     if exists('g:ctrlsf_width')

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -116,6 +116,12 @@ if !exists('g:ctrlsf_default_root')
 endif
 " }}}
 
+" g:ctrlsf_ignore_dir {{{2
+if !exists('g:ctrlsf_ignore_dir')
+    let g:ctrlsf_ignore_dir = []
+endif
+" }}}
+
 " g:ctrlsf_indent {{{2
 if !exists('g:ctrlsf_indent')
     let g:ctrlsf_indent = 4


### PR DESCRIPTION
feature:

1. add argument `-ignoredir` and option `g:ctrlsf_ignore_dir`.
2. add command `CtrlSFToggleMap` to toggle CtrlSF's mapping in result buffer.

fix:

1. use binary search to boost the processing of finding current cursor's position in result set.