### PR TITLE
Fix missing of escaping for '--ignore-dir'

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -41,7 +41,7 @@ func! s:BuildCommand(args) abort
     " ignore (dir, file)
     let ignore_dir = ctrlsf#opt#GetIgnoreDir()
     for dir in ignore_dir
-        call add(tokens, "--ignore-dir " . dir)
+        call add(tokens, "--ignore-dir " . shellescape(dir))
     endfor
 
     " regex

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -176,7 +176,11 @@ endf
 " GetIgnoreDir()
 "
 func! ctrlsf#opt#GetIgnoreDir() abort
-    return add(copy(g:ctrlsf_ignore_dir), ctrlsf#opt#GetOpt("ignoredir"))
+    let ignore_dir = copy(g:ctrlsf_ignore_dir)
+    if ctrlsf#opt#IsOptGiven("ignoredir")
+        call add(ignore_dir, ctrlsf#opt#GetOpt("ignoredir"))
+    endif
+    return ignore_dir
 endf
 
 """""""""""""""""""""""""""""""""


### PR DESCRIPTION
Hotfix for #86 .

The true reason for this issue is missing of `shellescape` for values of `--ignore-dir`.