### PR TITLE
Add commands to only show quick fix window results

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ An ack/ag/pt powered code search and view tool, like ack.vim or `:vimgrep` but t
 
 - Preview mode for fast exploring.
 
+- View location results in a quickfix window.
+
 - Various options for customized search, view and edit.
 
 ## Installation
@@ -65,6 +67,8 @@ An ack/ag/pt powered code search and view tool, like ack.vim or `:vimgrep` but t
 
 6. `:CtrlSFOpen` can reopen CtrlSF window when you have closed CtrlSF window. It is free because it won't invoke a same but new search. A handy command `:CtrlSFToggle` is also available.
 
+7. Alternatively run `:CtrlSFLocation [pattern]`, it will only open a quickfix window to show search result.
+
 ## Key Maps
 
 In CtrlSF window:
@@ -89,25 +93,25 @@ Some default defined keys may conflict with keys you have been used to when you 
 
 There are also some useful maps need to be mentioned.
 
-- `<Plug>CtrlSFPrompt`
+- `<Plug>CtrlSFPrompt` / `<Plug>CtrlSFLocationPrompt`
 
-    Input `:CtrlSF ` in command line for you, just a handy shortcut.
+    Input `:CtrlSF ` or `:CtrlSFLocation ` in command line for you, just a handy shortcut.
 
-- `<Plug>CtrlSFVwordPath`
+- `<Plug>CtrlSFVwordPath` / `<Plug>CtrlSFVwordPathLocation`
 
-    Input `:CtrlSF foo ` in command line where `foo` is the current visual selected word, waiting for further input.
+    Input `:CtrlSF foo ` or `:CtrlSFLocation foo ` in command line where `foo` is the current visual selected word, waiting for further input.
 
-- `<Plug>CtrlSFVwordExec`
+- `<Plug>CtrlSFVwordExec` / `<Plug>CtrlSFVwordExecLocation`
 
-    Like `<Plug>CtrlSFVwordPath`, but execute it immediately.
+    Like `<Plug>CtrlSFVwordPath`/`<Plug>CtrlSFVwordPathLocation`, but execute it immediately.
 
-- `<Plug>CtrlSFCwordPath`
+- `<Plug>CtrlSFCwordPath` / `<Plug>CtrlSFCwordPathLocation`
 
-    Input `:CtrlSF foo ` in command line where `foo` is word under the cursor.
+    Input `:CtrlSF foo ` or `:CtrlSFLocation foo ` in command line where `foo` is word under the cursor.
 
-- `<Plug>CtrlSFPwordPath`
+- `<Plug>CtrlSFPwordPath` / `<Plug>CtrlSFPwordPathLocation`
 
-    Input `:CtrlSF foo ` in command line where `foo` is the last search pattern of vim.
+    Input `:CtrlSF foo `  or `:CtrlSFLocation foo `in command line where `foo` is the last search pattern of vim.
 
 For a full list of maps, please refer to the document.
 
@@ -124,6 +128,9 @@ nmap     <C-F>p <Plug>CtrlSFPwordPath
 nnoremap <C-F>o :CtrlSFOpen<CR>
 nnoremap <C-F>t :CtrlSFToggle<CR>
 inoremap <C-F>t <Esc>:CtrlSFToggle<CR>
+nmap     <C-F>l <Plug>CtrlSFLocationPrompt
+vmap     <C-F>l <Plug>CtrlSFVwordPathLocation
+vmap     <C-F>L <Plug>CtrlSFVwordExecLocation
 ```
 
 ## Edit Mode

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -48,6 +48,35 @@ func! s:ExecSearch(args) abort
     call setloclist(0, ctrlsf#db#MatchListQF())
 endf
 
+" s:ExecSearchLocation()
+"
+" Basic process: query, parse, open quickfix and display.
+"
+func! s:ExecSearchLocation(args) abort
+    try
+        call ctrlsf#opt#ParseOptions(a:args)
+    catch /ParseOptionsException/
+        return -1
+    endtry
+
+    if ctrlsf#backend#SelfCheck() < 0
+        return -1
+    endif
+
+    let [success, output] = ctrlsf#backend#Run(a:args)
+    if !success
+        call ctrlsf#log#Error('Failed to call backend. Error messages: %s',
+            \ output)
+        return -1
+    endif
+
+    call ctrlsf#db#ParseAckprgResult(output)
+    " populate quickfix and location list then open
+    call setqflist(ctrlsf#db#MatchListQF())
+    call setloclist(0, ctrlsf#db#MatchListQF())
+    copen
+endf
+
 " Search()
 "
 func! ctrlsf#Search(args) abort
@@ -61,6 +90,21 @@ func! ctrlsf#Search(args) abort
     let s:current_query = args
 
     call s:ExecSearch(s:current_query)
+endf
+
+" SearchLocation()
+"
+func! ctrlsf#SearchLocation(args) abort
+    let args = a:args
+
+    " If no pattern is given, use word under the cursor
+    if empty(args)
+        let args = expand('<cword>')
+    endif
+
+    let s:current_query = args
+
+    call s:ExecSearchLocation(s:current_query)
 endf
 
 " Update()

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -82,6 +82,9 @@ A typical workflow using CtrlSF is like this:
   It is free because it won't invoke a same but new search. A useful command
   |:CtrlSFToggle| is also available.
 
+  7. Alternatively run `:CtrlSFLocation [pattern]`, it will only open a
+  quickfix window to show search results.
+
 Note: The result set will additionally be stored in a |location-list| of the
 CtrlSF window. Open it using |:lopen|
 
@@ -144,6 +147,12 @@ mode:
   is given, the default directory is used, which is specified by
   |g:ctrlsf_default_root|.
 
+:CtrlSFLocation [arguments] {pattern} [path] ...                *:CtrlSFLocation*
+
+  Similar to |:CtrlSF|. Search {pattern}. Default is search by literal. Show
+  result in a quickfix window if there is no existing one, otherwise reuse
+  that one.
+
 :CtrlSFOpen                                                        *:CtrlSFOpen*
 
   If CtrlSF window is closed (by <q> or |:CtrlSFClose|), reopen it. If the
@@ -181,20 +190,42 @@ mode:
     <Plug>CtrlSFPrompt      Input 'CtrlSF' in command line and waiting, just a
                             handy shortcut.
 
+    <Plug>CtrlSFLocationPrompt  Input 'CtrlSFLocation' in command line and
+                                waiting, just a handy shortcut to reveal in a
+                                quickfix window.
+
     <Plug>CtrlSFVwordPath   Input current visual selected word in command line
                             and waiting for any other user input.
 
+                            Use <Plug>CtrlSFVwordPathLocation for quickfix
+                            only window.
+
     <Plug>CtrlSFVwordExec   Similar to above, but execute it immediately.
+
+                            Use <Plug>CtrlSFVwordExecLocation for quickfix
+                            only window.
 
     <Plug>CtrlSFCwordPath   Input word in the cursor in command line and
                             waiting.
 
+                            Use <Plug>CtrlSFCwordPathLocation for quickfix
+                            only window.
+
     <Plug>CtrlSFCwordExec   Similar to above, but execute it immediately.
+
+                            Use <Plug>CtrlSFCwordExecLocation for quickfix
+                            only window.
 
     <Plug>CtrlSFPwordPath   Input last search pattern in command line and
                             waiting.
 
+                            Use <Plug>CtrlSFPwordPathLocation for quickfix
+                            only window.
+
     <Plug>CtrlSFPwordExec   Similar to above, but execute it immediately.
+
+                            Use <Plug>CtrlSFPwordExecLocation for quickfix
+                            only window.
 
   Maps by default in CtrlSF window:
 

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -64,6 +64,17 @@ func! s:SearchVwordCmd(to_exec)
 endf
 " }}}
 
+" s:SearchVwordCmdLocation() {{{2
+" Within evaluation of a expression typed visual map, we can not get
+" current visual selection normally, so I need to workaround it.
+func! s:SearchVwordCmdLocation(to_exec)
+    let keys = '":\<C-U>CtrlSFLocation " . g:CtrlSFGetVisualSelection()'
+    let keys .= a:to_exec ? '."\r"' : '." "'
+    let cmd = ":\<C-U>call feedkeys(" . keys . ", 'n')\r"
+    return cmd
+endf
+" }}}
+
 " s:SearchPwordCmd() {{{2
 func! s:SearchPwordCmd(to_exec)
     let cmd = ":\<C-U>CtrlSF " . @/
@@ -215,6 +226,7 @@ com! -n=0                                         CtrlSFUpdate  call ctrlsf#Upda
 com! -n=0                                         CtrlSFClose   call ctrlsf#Quit()
 com! -n=0                                         CtrlSFClearHL call ctrlsf#ClearSelectedLine()
 com! -n=0                                         CtrlSFToggle  call ctrlsf#Toggle()
+com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSFLocation call ctrlsf#SearchLocation(<q-args>)
 " }}}
 
 " Maps {{{1
@@ -225,6 +237,9 @@ vnoremap <expr> <Plug>CtrlSFVwordPath <SID>SearchVwordCmd(0)
 vnoremap <expr> <Plug>CtrlSFVwordExec <SID>SearchVwordCmd(1)
 nnoremap <expr> <Plug>CtrlSFPwordPath <SID>SearchPwordCmd(0)
 nnoremap <expr> <Plug>CtrlSFPwordExec <SID>SearchPwordCmd(1)
+nnoremap        <Plug>CtrlSFLocationPrompt :CtrlSFLocation<Space>
+vnoremap <expr> <Plug>CtrlSFVwordPathLocation <SID>SearchVwordCmdLocation(0)
+vnoremap <expr> <Plug>CtrlSFVwordExecLocation <SID>SearchVwordCmdLocation(1)
 " }}}
 
 " modeline {{{1

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -46,8 +46,8 @@ endf
 " }}}
 
 " s:SearchCwordCmd() {{{2
-func! s:SearchCwordCmd(to_exec)
-    let cmd = ":\<C-U>CtrlSF " . expand('<cword>')
+func! s:SearchCwordCmd(type, to_exec)
+    let cmd = ":\<C-U>" . a:type . " " . expand('<cword>')
     let cmd .= a:to_exec ? "\r" : " "
     return cmd
 endf
@@ -56,19 +56,8 @@ endf
 " s:SearchVwordCmd() {{{2
 " Within evaluation of a expression typed visual map, we can not get
 " current visual selection normally, so I need to workaround it.
-func! s:SearchVwordCmd(to_exec)
-    let keys = '":\<C-U>CtrlSF " . g:CtrlSFGetVisualSelection()'
-    let keys .= a:to_exec ? '."\r"' : '." "'
-    let cmd = ":\<C-U>call feedkeys(" . keys . ", 'n')\r"
-    return cmd
-endf
-" }}}
-
-" s:SearchVwordCmdLocation() {{{2
-" Within evaluation of a expression typed visual map, we can not get
-" current visual selection normally, so I need to workaround it.
-func! s:SearchVwordCmdLocation(to_exec)
-    let keys = '":\<C-U>CtrlSFLocation " . g:CtrlSFGetVisualSelection()'
+func! s:SearchVwordCmd(type, to_exec)
+    let keys = '":\<C-U>'. a:type .' " . g:CtrlSFGetVisualSelection()'
     let keys .= a:to_exec ? '."\r"' : '." "'
     let cmd = ":\<C-U>call feedkeys(" . keys . ", 'n')\r"
     return cmd
@@ -76,8 +65,8 @@ endf
 " }}}
 
 " s:SearchPwordCmd() {{{2
-func! s:SearchPwordCmd(to_exec)
-    let cmd = ":\<C-U>CtrlSF " . @/
+func! s:SearchPwordCmd(type, to_exec)
+    let cmd = ":\<C-U>" . a:type . " " . @/
     let cmd .= a:to_exec ? "\r" : " "
     return cmd
 endf
@@ -220,26 +209,31 @@ endif
 " }}}
 
 " Commands {{{1
-com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSF        call ctrlsf#Search(<q-args>)
+com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSF        call ctrlsf#Search(<q-args>, 0)
+com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSFLocation call ctrlsf#Search(<q-args>, 1)
 com! -n=0                                         CtrlSFOpen    call ctrlsf#Open()
-com! -n=0                                         CtrlSFUpdate  call ctrlsf#Update()
+com! -n=0                                         CtrlSFUpdate  call ctrlsf#Update(0)
 com! -n=0                                         CtrlSFClose   call ctrlsf#Quit()
 com! -n=0                                         CtrlSFClearHL call ctrlsf#ClearSelectedLine()
 com! -n=0                                         CtrlSFToggle  call ctrlsf#Toggle()
-com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSFLocation call ctrlsf#SearchLocation(<q-args>)
 " }}}
 
 " Maps {{{1
 nnoremap        <Plug>CtrlSFPrompt    :CtrlSF<Space>
-nnoremap <expr> <Plug>CtrlSFCwordPath <SID>SearchCwordCmd(0)
-nnoremap <expr> <Plug>CtrlSFCwordExec <SID>SearchCwordCmd(1)
-vnoremap <expr> <Plug>CtrlSFVwordPath <SID>SearchVwordCmd(0)
-vnoremap <expr> <Plug>CtrlSFVwordExec <SID>SearchVwordCmd(1)
-nnoremap <expr> <Plug>CtrlSFPwordPath <SID>SearchPwordCmd(0)
-nnoremap <expr> <Plug>CtrlSFPwordExec <SID>SearchPwordCmd(1)
+nnoremap <expr> <Plug>CtrlSFCwordPath <SID>SearchCwordCmd('CtrlSF', 0)
+nnoremap <expr> <Plug>CtrlSFCwordExec <SID>SearchCwordCmd('CtrlSF', 1)
+vnoremap <expr> <Plug>CtrlSFVwordPath <SID>SearchVwordCmd('CtrlSF', 0)
+vnoremap <expr> <Plug>CtrlSFVwordExec <SID>SearchVwordCmd('CtrlSF', 1)
+nnoremap <expr> <Plug>CtrlSFPwordPath <SID>SearchPwordCmd('CtrlSF', 0)
+nnoremap <expr> <Plug>CtrlSFPwordExec <SID>SearchPwordCmd('CtrlSF', 1)
+
 nnoremap        <Plug>CtrlSFLocationPrompt :CtrlSFLocation<Space>
-vnoremap <expr> <Plug>CtrlSFVwordPathLocation <SID>SearchVwordCmdLocation(0)
-vnoremap <expr> <Plug>CtrlSFVwordExecLocation <SID>SearchVwordCmdLocation(1)
+nnoremap <expr> <Plug>CtrlSFCwordPathLocation <SID>SearchCwordCmd('CtrlSFLocation', 0)
+nnoremap <expr> <Plug>CtrlSFCwordExecLocation <SID>SearchCwordCmd('CtrlSFLocation', 1)
+vnoremap <expr> <Plug>CtrlSFVwordPathLocation <SID>SearchVwordCmd('CtrlSFLocation', 0)
+vnoremap <expr> <Plug>CtrlSFVwordExecLocation <SID>SearchVwordCmd('CtrlSFLocation', 1)
+nnoremap <expr> <Plug>CtrlSFPwordPathLocation <SID>SearchPwordCmd('CtrlSFLocation', 0)
+nnoremap <expr> <Plug>CtrlSFPwordExecLocation <SID>SearchPwordCmd('CtrlSFLocation', 1)
 " }}}
 
 " modeline {{{1


### PR DESCRIPTION
This is a proof of concept requesting a new feature. Occasionally I’d like to perform a search and only view the results generated to the quick fix window instead of also viewing them in the larger editable panel. Having this ability would replace the need to also install plugins like ack.vim, ag.vim or ferret which display their results in either a quick fix or location list window. This would give all file searching the same API rather than flip flopping back and forth.

This commit adds 3 commands CtrlSFLocationPrompt, CtrlSFVwordPathLocation, CtrlSFVwordExecLocation to compliment the existing commands and behavior. For the most part the code has been duplicated and is not very DRY with the rest of the functions. No documentation has been added.

I'm curious if you would either add this feature into ctrlsf.vim or accept a more thorough PR?

thanks in advance.