### PR TITLE
Allow quickfix window to occupy the full Vim width

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -40,7 +40,7 @@ func! s:ExecSearch(args, only_quickfix) abort
     " Only populate and open the quickfix window
     if a:only_quickfix
       call setqflist(ctrlsf#db#MatchListQF())
-      copen
+      botright copen
       return
     endif
 


### PR DESCRIPTION
Pretty simple addition but makes navigating splits with the quick fix window results a little easier.