### PR TITLE
Ignore stderr, don't let it pollute the output

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -115,6 +115,9 @@ func! s:BuildCommand(args) abort
     " path
     call extend(tokens, ctrlsf#opt#GetPath())
 
+    " ignore stderr
+    call add(tokens, " 2>/dev/null")
+
     return join(tokens, ' ')
 endf
 


### PR DESCRIPTION
Sometimes the search ultilty will throw out error message via stderr, which causes trouble.
Most of the errors are relative with opening file/directory failed, so we can simply ignore them, and keep them away from desirable output.