### PR TITLE
Use builtin method tempname() instead

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -36,12 +36,8 @@ func! s:ExecSearch(args, only_quickfix) abort
     endif
 
     " Print error messages from backend (Debug Mode)
-    try
-        let err_msg = join(readfile(expand(g:ctrlsf_cmd_error_file), "\n"))
-        call ctrlsf#log#Debug("Errors reported by backend:\n%s", err_msg)
-    catch
-        call ctrlsf#log#Debug("Exception caught: %s", v:exception)
-    endtry
+    call ctrlsf#log#Debug("Errors reported by backend:\n%s",
+                \ ctrlsf#backend#LastErrors())
 
     " Parsing
     call ctrlsf#db#ParseAckprgResult(output)

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -5,6 +5,9 @@
 " Version: 1.7.4
 " ============================================================================
 
+" Log file that collects error messages from backend
+let s:backend_error_log_file = tempname()
+
 " BuildCommand()
 "
 func! s:BuildCommand(args) abort
@@ -176,6 +179,18 @@ func! ctrlsf#backend#Runner()
     endif
 endf
 
+" LastErrors()
+"
+func! ctrlsf#backend#LastErrors()
+    try
+        return join(readfile(expand(s:backend_error_log_file)), "\n")
+    catch
+        call ctrlsf#log#Debug("Exception caught in reading error los: %s",
+                    \ v:exception)
+        return ""
+    endtry
+endf
+
 " Run()
 "
 " Execute backend.
@@ -197,7 +212,7 @@ func! ctrlsf#backend#Run(args) abort
     set shelltemp
 
     let shrd_bak = &shellredir
-    let &shellredir='1>%s 2>'.g:ctrlsf_cmd_error_file
+    let &shellredir='1>%s 2>'.s:backend_error_log_file
 
     let output = system(command)
 

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -92,12 +92,6 @@ if !exists('g:ctrlsf_case_sensitive')
 endif
 " }}}
 
-" g:ctrlsf_cmd_error_file {{{2
-if !exists('g:ctrlsf_cmd_error_file')
-    let g:ctrlsf_cmd_error_file = '~/.ctrlsf_cmd_error_file'
-endif
-" }}}
-
 " g:ctrlsf_confirm_save {{{2
 if !exists('g:ctrlsf_confirm_save')
     let g:ctrlsf_confirm_save = 1


### PR DESCRIPTION
Predefined error log file's path is not compatible with windows platform.

Issue reported by #124 .