### PR TITLE
Feature/warn unsaved changes when quitting

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -132,8 +132,12 @@ endf
 " Quit()
 "
 func! ctrlsf#Quit() abort
-    call ctrlsf#preview#ClosePreviewWindow()
-    call ctrlsf#win#CloseMainWindow()
+    if g:ctrlsf_confirm_unsaving_quit &&
+                \ !ctrlsf#buf#WarnIfChanged()
+        return
+    endif
+
+    call s:Quit()
 endf
 
 " OpenLocList()
@@ -158,6 +162,11 @@ func! ctrlsf#JumpTo(mode) abort
     let [file, line, match] = ctrlsf#view#Reflect(line('.'))
 
     if empty(file) || empty(line)
+        return
+    endif
+
+    if g:ctrlsf_confirm_unsaving_quit &&
+                \ !ctrlsf#buf#WarnIfChanged()
         return
     endif
 
@@ -226,7 +235,7 @@ endf
 "
 func! s:OpenFileInWindow(file, lnum, col, mode, split) abort
     if a:mode == 1 && g:ctrlsf_auto_close
-        call ctrlsf#Quit()
+        call s:Quit()
     endif
 
     let target_winnr = ctrlsf#win#FindTargetWindow(a:file)
@@ -266,7 +275,7 @@ endf
 "
 func! s:OpenFileInTab(file, lnum, col, mode) abort
     if a:mode == 1 && g:ctrlsf_auto_close
-        call ctrlsf#Quit()
+        call s:Quit()
     endif
 
     exec 'silen tabedit ' . fnameescape(a:file)
@@ -305,6 +314,13 @@ func! s:PreviewFile(file, lnum, col, follow) abort
     if !a:follow
         call ctrlsf#win#FocusMainWindow()
     endif
+endf
+
+" s:Quit()
+"
+func! s:Quit() abort
+    call ctrlsf#preview#ClosePreviewWindow()
+    call ctrlsf#win#CloseMainWindow()
 endf
 
 " ClearSelectedLine()

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -165,7 +165,11 @@ func! ctrlsf#JumpTo(mode) abort
         return
     endif
 
-    if g:ctrlsf_confirm_unsaving_quit &&
+    if (a:mode ==# "open"
+                \ || a:mode ==# "split"
+                \ || a:mode ==# "vsplit"
+                \ || a:mode ==# "tab") &&
+                \ g:ctrlsf_confirm_unsaving_quit &&
                 \ !ctrlsf#buf#WarnIfChanged()
         return
     endif

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -38,7 +38,7 @@ endf
 func! ctrlsf#buf#WarnIfChanged() abort
     if getbufvar('%', '&modified')
         call ctrlsf#log#Warn("Will discard ALL unsaved changes, continue? (Y/n)")
-        let confirm = nr2char(getchar()) | redraw
+        let confirm = nr2char(getchar()) | redraw!
         if !(confirm ==? "y" || confirm ==? "\r")
             return 0
         endif

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -33,6 +33,19 @@ func! ctrlsf#buf#WriteFile(file) abort
     call setbufvar('%', '&modified', 0)
 endf
 
+" WarnIfChanged()
+"
+func! ctrlsf#buf#WarnIfChanged() abort
+    if getbufvar('%', '&modified')
+        call ctrlsf#log#Warn("Will discard ALL unsaved changes, continue? (Y/n)")
+        let confirm = nr2char(getchar()) | redraw
+        if !(confirm ==? "y" || confirm ==? "\r")
+            return 0
+        endif
+    endif
+    return 1
+endf
+
 " ClearUndoHistory()
 "
 func! ctrlsf#buf#ClearUndoHistory() abort

--- a/autoload/ctrlsf/edit.vim
+++ b/autoload/ctrlsf/edit.vim
@@ -196,7 +196,8 @@ func! ctrlsf#edit#Save() abort
 
     " prompt to confirm save
     if g:ctrlsf_confirm_save
-        echo printf("%s files will be saved. Confirm? (Y/n)", len(changed))
+        call ctrlsf#log#Info(printf("%s files will be saved. Confirm? (Y/n)",
+                    \ len(changed)))
         let confirm = nr2char(getchar()) | redraw
         if !(confirm ==? "y" || confirm ==? "\r")
             call ctrlsf#log#Info("Cancelled.")

--- a/autoload/ctrlsf/edit.vim
+++ b/autoload/ctrlsf/edit.vim
@@ -198,7 +198,7 @@ func! ctrlsf#edit#Save() abort
     if g:ctrlsf_confirm_save
         call ctrlsf#log#Info(printf("%s files will be saved. Confirm? (Y/n)",
                     \ len(changed)))
-        let confirm = nr2char(getchar()) | redraw
+        let confirm = nr2char(getchar()) | redraw!
         if !(confirm ==? "y" || confirm ==? "\r")
             call ctrlsf#log#Info("Cancelled.")
             return -1

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -358,6 +358,14 @@ you can turn off this confirmation by
 >
     let g:ctrlsf_confirm_save = 0
 <
+g:ctrlsf_confirm_unsaving_quit                *'g:ctrlsf_confirm_unsaving_quit'*
+Default: 1
+Confirm before quitting if there is any unsaved change. Usually it can protect
+you from occasionally pressing 'q' then all changes blow off. You can disable
+this protection by
+>
+    let g:ctrlsf_confirm_unsaving_quit = 0
+<
 g:ctrlsf_context                                            *'g:ctrlsf_context'*
 Default: '-C 3'
 Defines how many lines around the matching line will be printed. Use same format

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -97,6 +97,12 @@ if !exists('g:ctrlsf_confirm_save')
     let g:ctrlsf_confirm_save = 1
 endif
 " }}}
+"
+" g:ctrlsf_confirm_unsaving_quit {{{2
+if !exists('g:ctrlsf_confirm_unsaving_quit')
+    let g:ctrlsf_confirm_unsaving_quit = 1
+endif
+" }}}
 
 " g:ctrlsf_context {{{2
 if !exists('g:ctrlsf_context')


### PR DESCRIPTION
- Warn you before quitting CtrlSF window, if there is any unsaved change.
- Add new option `g:ctrlsf_confirm_unsaving_quit`.