### PR TITLE
Hotfix/backend error detection

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -219,8 +219,13 @@ func! ctrlsf#backend#Run(args) abort
     let &shelltemp = shtmp_bak
     let &shellredir = shrd_bak
 
-    if v:shell_error && !empty(output)
-        return [0, output]
+    if v:shell_error
+        let errmsg = ctrlsf#backend#LastErrors()
+        if !empty(errmsg)
+            return [0, errmsg]
+        else
+            return [1, output]
+        endif
     else
         return [1, output]
     endif

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -37,9 +37,9 @@ endf
 "
 func! ctrlsf#buf#WarnIfChanged() abort
     if getbufvar('%', '&modified')
-        call ctrlsf#log#Warn("Will discard ALL unsaved changes, continue? (Y/n)")
+        call ctrlsf#log#Warn("Will discard ALL unsaved changes, continue? (y/N)")
         let confirm = nr2char(getchar()) | redraw!
-        if !(confirm ==? "y" || confirm ==? "\r")
+        if !(confirm ==? "y")
             return 0
         endif
     endif


### PR DESCRIPTION
Fix two things:

- error message is not properly displayed.
- possibly discarding changes by hitting Enter key accidentally.