### PR TITLE
Use relative path as filename if possible

### DIFF
--- a/autoload/ctrlsf/class/paragraph.vim
+++ b/autoload/ctrlsf/class/paragraph.vim
@@ -11,7 +11,7 @@
 " 'buffer' is a list of defactorized line [fname, lnum, content].
 "
 func! ctrlsf#class#paragraph#New(buffer) abort
-    let fname = a:buffer[0][0]
+    let fname = s:ShortenFilename(a:buffer[0][0])
 
     let paragraph = {
         \ 'filename'  : fname,
@@ -77,4 +77,12 @@ endf
 "
 func! ctrlsf#class#paragraph#TrimTail() abort dict
     call remove(self.lines, -1)
+endf
+
+" ShortenFilename()
+"
+" Simplify filename into a relative path if possible
+"
+func! s:ShortenFilename(filename) abort
+    return substitute(a:filename, '^'.getcwd().'[\\/]', '', '')
 endf


### PR DESCRIPTION
Use relative path as a filename by default. 

FIx #147 .