### PR TITLE
Feature/compact view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Here we rename a method named `MoveCursor()` to `Cursor()` in multiple files, us
 - [Use Your Own Map](#use-your-own-map)
 - [Edit Mode](#edit-mode)
   - [Limitation](#limitation)
-- [Quickfix Mode](#quickfix-mode)
 - [Arguments](#arguments)
   - [Example](#example)
 - [Tips](#tips)
@@ -38,7 +37,7 @@ Here we rename a method named `MoveCursor()` to `Cursor()` in multiple files, us
 
 - Preview mode for fast exploring.
 
-- View results in a quickfix window if you feel more familiar with quickfix window.
+- Two types of views. For both users who like a sublime-like, rich context result window, or who feel more comfortable with good old quickfix window. (similar to ack.vim)
 
 - Various options for customized search, view and edit.
 
@@ -70,8 +69,7 @@ Here we rename a method named `MoveCursor()` to `Cursor()` in multiple files, us
 
 6. `:CtrlSFOpen` can reopen CtrlSF window when you have closed CtrlSF window. It is free because it won't invoke a same but new search. A handy command `:CtrlSFToggle` is also available.
 
-7. Alternatively run `:CtrlSFQuickfix [pattern]`, it will only open a quickfix
-   window to show search result.
+7. If you prefer a quickfix-like result window, just try to press `M` in CtrlSF window.
 
 ## Key Maps
 
@@ -84,6 +82,7 @@ In CtrlSF window:
 - `P` - Like `Enter` but open file in a preview window and switch focus to it.
 - `O` - Like `Enter` but always leave CtrlSF window opening.
 - `T` - Like `t` but focus CtrlSF window instead of new opened tab.
+- `M` - Switch result window between **normal** view and **compact** view.
 - `q` - Quit CtrlSF window.
 - `<C-J>` - Move cursor to next match.
 - `<C-K>` - Move cursor to previous match.
@@ -122,12 +121,6 @@ CtrlSF provides many maps you can use for quick accessing all features, here I l
 
     Input `:CtrlSF foo ` in command line where `foo` is the last search pattern of vim.
 
-There are also some maps for quickfix mode, for example:
-
-- `<Plug>CtrlsfQuickfixPrompt`
-
-    like `<Plug>CtrlSFPrompt` but instead invoking `:CtrlSFQuickfix`.
-
 For a full list of maps, please refer to the document.
 
 I strongly recommend you should do some maps for a nicer user experience, because typing 8 characters for every single search is really boring and painful experience. Another reason is that **one of the most useful feature 'Search Visual Selected Word' can be accessed by map only.**
@@ -143,9 +136,6 @@ nmap     <C-F>p <Plug>CtrlSFPwordPath
 nnoremap <C-F>o :CtrlSFOpen<CR>
 nnoremap <C-F>t :CtrlSFToggle<CR>
 inoremap <C-F>t <Esc>:CtrlSFToggle<CR>
-nmap     <C-F>l <Plug>CtrlSFQuickfixPrompt
-vmap     <C-F>l <Plug>CtrlSFQuickfixVwordPath
-vmap     <C-F>L <Plug>CtrlSFQuickfixVwordExec
 ```
 
 ## Edit Mode
@@ -163,24 +153,6 @@ vmap     <C-F>L <Plug>CtrlSFQuickfixVwordExec
 - You can modify or delete lines but **you can't insert**. (If it turns out that inserting is really needed, I'll implement it later.)
 
 - If a file's content varies from last search, CtrlSF will refuse to write your changes to that file (for safety concern). As a rule of thumb, invoke a new search before editing, or just run `:CtrlSFUpdate`.
-
-## Quickfix Mode
-
-The primary motivation of creating CtrlSF is being tired of small, context free quickfix window, so there is no Quickfix Mode in CtrlSF at first. But some users requested for Quickfix Mode as they need it in some cases, I accepted, Quickfix Mode was then finally added into CtrlSF (#94).
-
-You can access Quickfix Mode by commands and maps.
-
-Command:
-
-- `:CtrlSFQuickfix [pattern]`
-
-Maps:
-
-- <Plug>CtrlSFQuickfixPrompt
-- <Plug>CtrlSFQuickfixVwordPath
-- <Plug>CtrlSFQuickfixVwordExec
-
-But, **as I've no idea about reinventing another ack.vim, only minimum features are implemented in Quickfix Mode. Actually no customization beyond normal quickfix window is applied currently, I choose to leave it to users.**
 
 ## Arguments
 
@@ -245,10 +217,17 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
     ```vim
     let g:ctrlsf_context = '-B 5 -A 3'
     ```
+
 - `g:ctrlsf_default_root` defines how CtrlSF find search root when no explicit path is given. Two possible values are `cwd` and `project`. `cwd` means current working directory and `project` means project root. CtrlSF locates project root by searching VCS root (.git, .hg, .svn, etc.)
 
     ```vim
     let g:ctrlsf_default_root = 'project'
+    ```
+
+- `g:ctrlsf_default_view_mode` defines default view mode which CtrlSF will use. Possible values are `normal` and `compact`. The default value is `normal`.
+
+    ```vim
+    let g:ctrlsf_default_view_mode = 'compact'
     ```
 
 - `g:ctrlsf_extra_backend_args` is a dictionary that defines extra arguments that will be passed *literally* to backend, especially useful when you have your favorite backend and need some backend-specific features. For example, using `ptignore` file for [pt][8] should be like

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -256,9 +256,9 @@ endf
 " CurrentMode()
 "
 func! ctrlsf#CurrentMode()
-    let mode = empty(s:current_mode) ? 'normal' : s:current_mode
-    call ctrlsf#log#Debug("Current Mode: %s", mode)
-    return mode
+    let vmode = empty(s:current_mode) ? 'normal' : s:current_mode
+    call ctrlsf#log#Debug("Current Mode: %s", vmode)
+    return vmode
 endf
 
 " OpenFileInWindow()

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -12,13 +12,12 @@
 " remember what user is searching
 let s:current_mode = ''
 let s:current_query = ''
-let s:only_quickfix = 0
 
 " s:ExecSearch()
 "
 " Basic process: query, parse, render and display.
 "
-func! s:ExecSearch(args, only_quickfix) abort
+func! s:ExecSearch(args) abort
     try
         call ctrlsf#opt#ParseOptions(a:args)
     catch /ParseOptionsException/
@@ -43,13 +42,7 @@ func! s:ExecSearch(args, only_quickfix) abort
     " Parsing
     call ctrlsf#db#ParseAckprgResult(output)
 
-    " Only populate and open the quickfix window
-    if a:only_quickfix
-      call setqflist(ctrlsf#db#MatchListQF())
-      botright copen
-      return
-    endif
-
+    " Open and draw contents
     call s:OpenAndDraw()
 
     " populate quickfix and location list
@@ -61,7 +54,7 @@ endf
 
 " Search()
 "
-func! ctrlsf#Search(args, only_quickfix) abort
+func! ctrlsf#Search(args, ...) abort
     let args = a:args
 
     " If no pattern is given, use word under the cursor
@@ -70,10 +63,13 @@ func! ctrlsf#Search(args, only_quickfix) abort
     endif
 
     let s:current_query = args
-    let s:current_mode  = g:ctrlsf_default_view_mode
-    let s:only_quickfix = a:only_quickfix
 
-    call s:ExecSearch(s:current_query, s:only_quickfix)
+    " if view mode is not specified, use 'g:ctrlsf_default_view_mode'
+    let s:current_mode  = empty(a:000) ?
+                \ g:ctrlsf_default_view_mode :
+                \ a:1
+
+    call s:ExecSearch(s:current_query)
 endf
 
 " Update()
@@ -82,7 +78,7 @@ func! ctrlsf#Update() abort
     if empty(s:current_query)
         return -1
     endif
-    call s:ExecSearch(s:current_query, s:only_quickfix)
+    call s:ExecSearch(s:current_query)
 endf
 
 " Open()
@@ -111,6 +107,16 @@ func! ctrlsf#SwitchViewMode() abort
 
     call ctrlsf#Quit()
     call s:OpenAndDraw()
+endf
+
+" Quickfix()
+"
+" This is DEPRECATED method which is used only for backward-compatible
+"
+func! ctrlsf#Quickfix(args) abort
+    call ctrlsf#log#Notice("CtrlSFQuickfix is DEPRECATED! Invoking CtrlSF's compact view instead.")
+    sleep 1
+    call ctrlsf#Search(a:args, 'compact')
 endf
 
 " Save()

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -111,12 +111,15 @@ func! ctrlsf#SwitchViewMode() abort
 
     call ctrlsf#Quit()
     call s:OpenAndDraw()
-    call ctrlsf#hl#ReloadSyntax()
 endf
 
 " Save()
 "
 func! ctrlsf#Save()
+    if ctrlsf#CurrentMode() !=# 'normal'
+        ctrlsf#log#Notice("Edit mode is disabled in compact view.")
+    endif
+
     if !&l:modified
         return
     endif
@@ -228,6 +231,10 @@ endf
 " Move cursor to the next match after current cursor position.
 "
 func! ctrlsf#NextMatch(forward) abort
+    if ctrlsf#CurrentMode() !=# 'normal'
+        return
+    endif
+
     let [_, cur_vlnum, cur_vcol, _] = getpos('.')
     let [vlnum, vcol] = ctrlsf#view#FindNextMatch(a:forward, &wrapscan)
 
@@ -359,6 +366,7 @@ func! s:OpenAndDraw() abort
     call ctrlsf#win#OpenMainWindow()
     call ctrlsf#win#Draw()
     call ctrlsf#buf#ClearUndoHistory()
+    call ctrlsf#hl#ReloadSyntax()
     call ctrlsf#hl#HighlightMatch()
 
     " scroll up to top line

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -96,6 +96,7 @@ func! ctrlsf#buf#ToggleMap(...) abort
         \ "quit"    : "ctrlsf#Quit()",
         \ "next"    : "ctrlsf#NextMatch(1)",
         \ "prev"    : "ctrlsf#NextMatch(0)",
+        \ "chgmode" : "ctrlsf#SwitchViewMode()",
         \ "loclist" : "ctrlsf#OpenLocList()",
         \ "prevw"   : "ctrlsf#JumpTo('preview')",
         \ }

--- a/autoload/ctrlsf/buf.vim
+++ b/autoload/ctrlsf/buf.vim
@@ -50,11 +50,14 @@ endf
 "
 func! ctrlsf#buf#ClearUndoHistory() abort
     let modified_bak = getbufvar('%', '&modified')
+    let modifiable_bak = getbufvar('%', '&modifiable')
+    setl modifiable
     let ul_bak = &undolevels
     set undolevels=-1
     exe "normal a \<BS>\<Esc>"
     let &undolevels = ul_bak
     unlet ul_bak
+    call setbufvar('%', '&modifiable', modifiable_bak)
     call setbufvar('%', '&modified', modified_bak)
 endf
 

--- a/autoload/ctrlsf/hl.vim
+++ b/autoload/ctrlsf/hl.vim
@@ -15,7 +15,7 @@ func! ctrlsf#hl#HighlightMatch(...) abort
         return -1
     endif
 
-    let pattern = ctrlsf#opt#GetOpt("_vimhlregex")
+    let pattern = ctrlsf#opt#GetOpt("_vimhlregex")[ctrlsf#CurrentMode()]
     call ctrlsf#log#Debug("HighlightRegex: %s", pattern)
 
     silent! call matchdelete(w:ctrlsf_match_hlid)

--- a/autoload/ctrlsf/hl.vim
+++ b/autoload/ctrlsf/hl.vim
@@ -37,3 +37,9 @@ endf
 func! ctrlsf#hl#ClearSelectedLine() abort
     silent! call matchdelete(w:ctrlsf_line_hlid)
 endf
+
+" ReloadSyntax()
+"
+func! ctrlsf#hl#ReloadSyntax() abort
+    runtime syntax/ctrlsf.vim
+endf

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -289,7 +289,10 @@ func! ctrlsf#opt#ParseOptions(options_str) abort
     let s:options["_vimregex"] = ctrlsf#pat#Regex()
 
     " vimhlregex
-    let s:options["_vimhlregex"] = ctrlsf#pat#HighlightRegex()
+    let s:options["_vimhlregex"] = {
+                \ 'normal': ctrlsf#pat#HighlightRegex('normal'),
+                \ 'compact': ctrlsf#pat#HighlightRegex('compact')
+                \ }
 
     call ctrlsf#log#Debug("Options: %s", string(s:options))
 endf

--- a/autoload/ctrlsf/pat.vim
+++ b/autoload/ctrlsf/pat.vim
@@ -76,7 +76,7 @@ endf
 
 " HighlightRegex()
 "
-func! ctrlsf#pat#HighlightRegex() abort
+func! ctrlsf#pat#HighlightRegex(vmode) abort
     let base = ctrlsf#pat#Regex()
 
     let magic   = strpart(base, 0, 2)
@@ -85,10 +85,19 @@ func! ctrlsf#pat#HighlightRegex() abort
 
     " sign (to prevent matching out of file body)
     let sign = ''
-    if magic ==# '\v'
-        let sign = '(^\d+:.*)@<='
+
+    if a:vmode ==# 'normal'
+        if magic ==# '\v'
+            let sign = '(^\d+:.*)@<='
+        else
+            let sign = '\(\^\d\+:\.\*\)\@<='
+        endif
     else
-        let sign = '\(\^\d\+:\.\*\)\@<='
+        if magic ==# '\v'
+            let sign = '(\|\d+ col \d+\|.*)@<='
+        else
+            let sign = '\(|\d\+ col \d\+|\.\*\)\@<='
+        endif
     endif
 
     return printf('%s%s%s%s', magic, case, sign, pattern)

--- a/autoload/ctrlsf/preview.vim
+++ b/autoload/ctrlsf/preview.vim
@@ -20,18 +20,29 @@ func! ctrlsf#preview#OpenPreviewWindow() abort
     " be sure doing this only when *opening new window*
     call ctrlsf#win#BackupAllWinSize()
 
-    if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
-        let ctrlsf_width  = winwidth(0)
-        let winsize = min([&columns-ctrlsf_width, ctrlsf_width])
+    let mode = ctrlsf#CurrentMode()
+
+    if mode ==# 'normal'
+        " normal mode
+        if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+            let ctrlsf_width  = winwidth(0)
+            let winsize = min([&columns-ctrlsf_width, ctrlsf_width])
+        else
+            let ctrlsf_height  = winheight(0)
+            let winsize = min([&lines-ctrlsf_height, ctrlsf_height])
+        endif
+
+        let openpos = {
+                \ 'bottom': 'leftabove',  'right' : 'leftabove vertical',
+                \ 'top'   : 'rightbelow',  'left' : 'rightbelow vertical'}
+                \[g:ctrlsf_position] . ' '
     else
-        let ctrlsf_height  = winheight(0)
-        let winsize = min([&lines-ctrlsf_height, ctrlsf_height])
+        " compact mode
+        let winsize = &lines - 20
+        let openpos = 'leftabove'
     endif
 
-    let openpos = {
-            \ 'bottom': 'leftabove',  'right' : 'leftabove vertical',
-            \ 'top'   : 'rightbelow',  'left' : 'rightbelow vertical'}
-            \[g:ctrlsf_position] . ' '
+    " open window
     exec 'silent keepalt ' . openpos . winsize . 'split ' . '__CtrlSFPreview__'
 
     call s:InitPreviewWindow()

--- a/autoload/ctrlsf/preview.vim
+++ b/autoload/ctrlsf/preview.vim
@@ -20,9 +20,9 @@ func! ctrlsf#preview#OpenPreviewWindow() abort
     " be sure doing this only when *opening new window*
     call ctrlsf#win#BackupAllWinSize()
 
-    let mode = ctrlsf#CurrentMode()
+    let vmode = ctrlsf#CurrentMode()
 
-    if mode ==# 'normal'
+    if vmode ==# 'normal'
         " normal mode
         if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
             let ctrlsf_width  = winwidth(0)

--- a/autoload/ctrlsf/utils.vim
+++ b/autoload/ctrlsf/utils.vim
@@ -92,7 +92,7 @@ endf
 " Show filename of which cursor is currently placed in
 "
 func! ctrlsf#utils#SectionC()
-    let [file, _, _] = ctrlsf#view#Reflect(line('.'))
+    let [file, _, _] = ctrlsf#view#Locate(line('.'))
     return empty(file) ? '' : file
 endf
 
@@ -101,7 +101,7 @@ endf
 " Show total number of matches and current matching
 "
 func! ctrlsf#utils#SectionX()
-    let [file, line, match] = ctrlsf#view#Reflect(line('.'))
+    let [file, line, match] = ctrlsf#view#Locate(line('.'))
     if !empty(match)
         let matchlist = ctrlsf#db#MatchList()
         let total     = len(matchlist)

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -36,27 +36,40 @@ func! ctrlsf#win#OpenMainWindow() abort
     " be sure doing this only when *opening new window*
     call ctrlsf#win#BackupAllWinSize()
 
-    if g:ctrlsf_winsize =~ '\d\{1,2}%'
-        if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
-            let winsize = &columns * str2nr(g:ctrlsf_winsize) / 100
+    let mode = ctrlsf#CurrentMode()
+
+    if mode ==# 'normal'
+        " normal mode
+        if g:ctrlsf_winsize =~ '\d\{1,2}%'
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+                let winsize = &columns * str2nr(g:ctrlsf_winsize) / 100
+            else
+                let winsize = &lines * str2nr(g:ctrlsf_winsize) / 100
+            endif
+        elseif g:ctrlsf_winsize =~ '\d\+'
+            let winsize = str2nr(g:ctrlsf_winsize)
         else
-            let winsize = &lines * str2nr(g:ctrlsf_winsize) / 100
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+                let winsize = &columns / 2
+            else
+                let winsize = &lines / 2
+            endif
         endif
-    elseif g:ctrlsf_winsize =~ '\d\+'
-        let winsize = str2nr(g:ctrlsf_winsize)
+
+        let openpos = {
+              \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
+              \ 'bottom' : 'botright', 'right' : 'botright vertical'}
+              \[g:ctrlsf_position] . ' '
     else
-        if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
-            let winsize = &columns / 2
-        else
-            let winsize = &lines / 2
-        endif
+        " compact mode: fixed window size and position
+        let winsize = 10
+        let openpos = 'botright'
     endif
 
-    let openpos = {
-          \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
-          \ 'bottom' : 'botright', 'right' : 'botright vertical'}
-          \[g:ctrlsf_position] . ' '
-    exec 'silent keepalt ' . openpos . winsize . 'split ' . (bufnr('__CtrlSF__') != -1 ? '+b'.bufnr('__CtrlSF__') : '__CtrlSF__')
+
+    " open window
+    exec 'silent keepalt ' . openpos . winsize . 'split ' .
+                \ (bufnr('__CtrlSF__') != -1 ? '+b'.bufnr('__CtrlSF__') : '__CtrlSF__')
 
     call s:InitMainWindow()
 
@@ -129,7 +142,8 @@ func! s:InitMainWindow() abort
     endif
 
     " cmd
-    command! -buffer CtrlSFToggleMap call ctrlsf#ToggleMap()
+    command! -buffer CtrlSFToggleMap      call ctrlsf#ToggleMap()
+    command! -buffer CtrlSFSwitchViewMode call ctrlsf#SwitchViewMode()
 
     " autocmd
     augroup ctrlsf
@@ -145,7 +159,6 @@ func! s:InitMainWindow() abort
 
     let b:ctrlsf_initialized = 1
 endf
-
 
 """""""""""""""""""""""""""""""""
 " Window Navigation

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -75,9 +75,9 @@ func! ctrlsf#win#OpenMainWindow() abort
 
     " set 'modifiable' flag depending on current view mode
     if ctrlsf#CurrentMode() ==# 'normal'
-        set modifiable
+        setl modifiable
     else
-        set nomodifiable
+        setl nomodifiable
     endif
 
     " resize other windows

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -36,9 +36,9 @@ func! ctrlsf#win#OpenMainWindow() abort
     " be sure doing this only when *opening new window*
     call ctrlsf#win#BackupAllWinSize()
 
-    let mode = ctrlsf#CurrentMode()
+    let vmode = ctrlsf#CurrentMode()
 
-    if mode ==# 'normal'
+    if vmode ==# 'normal'
         " normal mode
         if g:ctrlsf_winsize =~ '\d\{1,2}%'
             if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -73,6 +73,13 @@ func! ctrlsf#win#OpenMainWindow() abort
 
     call s:InitMainWindow()
 
+    " set 'modifiable' flag depending on current view mode
+    if ctrlsf#CurrentMode() ==# 'normal'
+        set modifiable
+    else
+        set nomodifiable
+    endif
+
     " resize other windows
     call s:ResizeNeighborWins()
 endf

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -82,8 +82,8 @@ A typical workflow using CtrlSF is like this:
   It is free because it won't invoke a same but new search. A useful command
   |:CtrlSFToggle| is also available.
 
-  7. Alternatively run `:CtrlSFQuickfix [pattern]`, it will only open a
-  quickfix window to show search results.
+  7. If you prefer a quickfix-like result window, just try to press `M` in
+  CtrlSF window.
 
 Note: The result set will additionally be stored in a |location-list| of the
 CtrlSF window. Open it using |:lopen|
@@ -147,12 +147,6 @@ mode:
   is given, the default directory is used, which is specified by
   |g:ctrlsf_default_root|.
 
-:CtrlSFQuickfix [arguments] {pattern} [path] ...               *:CtrlSFQuickfix*
-
-  Similar to |:CtrlSF|. Search {pattern}. Default is search by literal. Show
-  result in a quickfix window if there is no existing one, otherwise reuse
-  that one.
-
 :CtrlSFOpen                                                        *:CtrlSFOpen*
 
   If CtrlSF window is closed (by <q> or |:CtrlSFClose|), reopen it. If the
@@ -190,53 +184,25 @@ mode:
     <Plug>CtrlSFPrompt      Input 'CtrlSF' in command line and waiting, just a
                             handy shortcut.
 
-    <Plug>CtrlSFQuickfixPrompt  Input 'CtrlSFQuickfix' in command line and
-                                waiting, just a handy shortcut to reveal in a
-                                quickfix window.
-
     <Plug>CtrlSFVwordPath    Input current visual selected word in command line
                              and waiting for any other user input.
 
-                             Use <Plug>CtrlSFQuickfixVwordPath for quickfix
-                             only window.
-
     <Plug>CtrlSFVwordExec    Similar to above, but execute it immediately.
-
-                             Use <Plug>CtrlSFQuickfixVwordExec for quickfix
-                             only window.
 
     <Plug>CtrlSFCwordPath    Input word in the cursor in command line and
                              waiting.
 
-                             Use <Plug>CtrlSFQuickfixCwordPath for quickfix
-                             only window.
-
     <Plug>CtrlSFCwordExec    Similar to above, but execute it immediately.
-
-                             Use <Plug>CtrlSFQuickfixCwordExec for quickfix
-                             only window.
 
     <Plug>CtrlSFCCwordPath   Similar to <Plug>CtrlSFCwordPath but will add word
                              boundary around searching word.
 
-                             Use <Plug>CtrlSFQuickfixCCwordPath for quickfix
-                             only window.
-
     <Plug>CtrlSFCCwordExec   Similar to above, but execute it immediately.
-
-                             Use <Plug>CtrlSFQuickfixCCwordExec for quickfix
-                             only window.
 
     <Plug>CtrlSFPwordPath    Input last search pattern in command line and
                              waiting.
 
-                             Use <Plug>CtrlSFQuickfixPwordPath for quickfix
-                             only window.
-
     <Plug>CtrlSFPwordExec    Similar to above, but execute it immediately.
-
-                             Use <Plug>CtrlSFQuickfixPwordExec for quickfix
-                             only window.
 
   Maps by default in CtrlSF window:
 
@@ -426,6 +392,14 @@ Explanation for each option:
     Option 'project' is identical to 'project+ff'.
 >
     let g:ctrlsf_default_root = 'project+fw'
+<
+g:ctrlsf_default_view_mode                        *'g:ctrlsf_default_view_mode'*
+Default: 'normal'
+Available: 'normal', 'compact'
+Defines default view mode of CtrlSF result window. 'normal' is a Sublime-like
+view and 'compact' is a quickfix-like view.
+>
+    let g:ctrlsf_debug_mode = 'compact
 <
 g:ctrlsf_extra_backend_args                      *'g:ctrlsf_extra_backend_args'*
 Default: {}

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -127,6 +127,12 @@ if !exists('g:ctrlsf_default_root')
 endif
 " }}}
 
+" g:ctrlsf_default_view_mode {{{2
+if !exists('g:ctrlsf_default_view_mode')
+    let g:ctrlsf_default_view_mode = 'normal'
+endif
+" }}}
+
 " g:ctrlsf_extra_backend_args {{{2
 if !exists('g:ctrlsf_extra_backend_args')
     let g:ctrlsf_extra_backend_args = {}
@@ -158,6 +164,7 @@ let s:default_mapping = {
     \ "quit"    : "q",
     \ "next"    : "<C-J>",
     \ "prev"    : "<C-K>",
+    \ "chgmode" : "<C-S>",
     \ "pquit"   : "q",
     \ "loclist" : "",
     \ }

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -164,7 +164,7 @@ let s:default_mapping = {
     \ "quit"    : "q",
     \ "next"    : "<C-J>",
     \ "prev"    : "<C-K>",
-    \ "chgmode" : "<C-S>",
+    \ "chgmode" : "M",
     \ "pquit"   : "q",
     \ "loclist" : "",
     \ }

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -229,8 +229,8 @@ endif
 " }}}
 
 " Commands {{{1
-com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSF         call ctrlsf#Search(<q-args>, 0)
-com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSFQuickfix call ctrlsf#Search(<q-args>, 1)
+com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSF         call ctrlsf#Search(<q-args>)
+com! -n=* -comp=customlist,ctrlsf#comp#Completion CtrlSFQuickfix call ctrlsf#Quickfix(<q-args>)
 com! -n=0                                         CtrlSFOpen     call ctrlsf#Open()
 com! -n=0                                         CtrlSFUpdate   call ctrlsf#Update()
 com! -n=0                                         CtrlSFClose    call ctrlsf#Quit()

--- a/syntax/ctrlsf.vim
+++ b/syntax/ctrlsf.vim
@@ -5,40 +5,39 @@
 " Version: 1.8.3
 " ============================================================================
 
-let mode = ctrlsf#CurrentMode()
+let vmode = ctrlsf#CurrentMode()
 
 if exists('b:current_syntax')
             \ && exists('b:current_view_mode')
-            \ && b:current_view_mode ==# mode
+            \ && b:current_view_mode ==# vmode
     finish
 endif
 
 " clear previous syntax
 syntax clear
 
-if mode ==# 'normal'
+if vmode ==# 'normal'
     syntax case match
     syntax match ctrlsfFilename    /^.*\ze:$/
     syntax match ctrlsfLnumMatch   /^\d\+:/
     syntax match ctrlsfLnumUnmatch /^\d\+-/
     syntax match ctrlsfCuttingLine /^\.\+$/
-
-    hi def link ctrlsfFilename     Title
-    hi def link ctrlsfLnumMatch    SignColumn
-    hi def link ctrlsfLnumUnmatch  LineNr
-    hi def link ctrlsfSelectedLine Visual
-    hi def link ctrlsfMatch        MatchParen
 else
     syntax case match
     syntax match qfLineNr     /[^|]*/  contained contains=qfError
     syntax match qfSeparator  /|/  contained nextgroup=qfLineNr
     syntax match qfFileName   /^[^|]*/  nextgroup=qfSeparator
     syntax match qfError      /error/  contained
-
-    hi def link qfFileName    Directory
-    hi def link qfError       Error
-    hi def link ctrlsfMatch   MatchParen
 endif
 
-let b:current_view_mode = mode
+" highlightment group can be shared between different syntaxes
+hi def link ctrlsfFilename     Title
+hi def link ctrlsfLnumMatch    SignColumn
+hi def link ctrlsfLnumUnmatch  LineNr
+hi def link ctrlsfSelectedLine Visual
+hi def link ctrlsfMatch        MatchParen
+hi def link qfFileName         Directory
+hi def link qfError            Error
+
+let b:current_view_mode = vmode
 let b:current_syntax = 'ctrlsf'

--- a/syntax/ctrlsf.vim
+++ b/syntax/ctrlsf.vim
@@ -5,20 +5,40 @@
 " Version: 1.8.3
 " ============================================================================
 
+let mode = ctrlsf#CurrentMode()
+
 if exists('b:current_syntax')
+            \ && exists('b:current_view_mode')
+            \ && b:current_view_mode ==# mode
     finish
 endif
 
-syntax case match
-syntax match ctrlsfFilename    /^.*\ze:$/
-syntax match ctrlsfLnumMatch   /^\d\+:/
-syntax match ctrlsfLnumUnmatch /^\d\+-/
-syntax match ctrlsfCuttingLine /^\.\+$/
+" clear previous syntax
+syntax clear
 
-hi def link ctrlsfFilename     Title
-hi def link ctrlsfMatch        MatchParen
-hi def link ctrlsfLnumMatch    SignColumn
-hi def link ctrlsfLnumUnmatch  LineNr
-hi def link ctrlsfSelectedLine Visual
+if mode ==# 'normal'
+    syntax case match
+    syntax match ctrlsfFilename    /^.*\ze:$/
+    syntax match ctrlsfLnumMatch   /^\d\+:/
+    syntax match ctrlsfLnumUnmatch /^\d\+-/
+    syntax match ctrlsfCuttingLine /^\.\+$/
 
+    hi def link ctrlsfFilename     Title
+    hi def link ctrlsfLnumMatch    SignColumn
+    hi def link ctrlsfLnumUnmatch  LineNr
+    hi def link ctrlsfSelectedLine Visual
+    hi def link ctrlsfMatch        MatchParen
+else
+    syntax case match
+    syntax match qfLineNr     /[^|]*/  contained contains=qfError
+    syntax match qfSeparator  /|/  contained nextgroup=qfLineNr
+    syntax match qfFileName   /^[^|]*/  nextgroup=qfSeparator
+    syntax match qfError      /error/  contained
+
+    hi def link qfFileName    Directory
+    hi def link qfError       Error
+    hi def link ctrlsfMatch   MatchParen
+endif
+
+let b:current_view_mode = mode
 let b:current_syntax = 'ctrlsf'


### PR DESCRIPTION
Add a compact view for CtrlSF window, which is more familiar to user who loves quickfix window.

![screen shot 2017-02-19 at 3 09 48 pm](https://cloud.githubusercontent.com/assets/1492050/23100192/9414e6cc-f6b5-11e6-85a6-1f414a10b30d.png)

- use `M` to switch CtrlSF window between 'norma' and 'compact' view.
- set compact view as default by `let g:ctrlsf_default_view_mode = 'compact'`.

Thanks to user @skamsie and @synic .