### PR TITLE
Add double dash option to support searching patterns that start with dash

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -147,6 +147,9 @@ func! s:BuildCommand(args) abort
         call add(tokens, extra_args)
     endif
 
+    " no more flags
+    call add(tokens, "--")
+
     " pattern (including escape)
     call add(tokens, shellescape(ctrlsf#opt#GetOpt('pattern')))
 

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -217,6 +217,7 @@ endf
 "
 func! s:ParseOptions(options_str) abort
     let options = {}
+    let no_more_options = 0
     let tokens  = ctrlsf#lex#Tokenize(a:options_str)
 
     let i = 0
@@ -225,7 +226,10 @@ func! s:ParseOptions(options_str) abort
         let i += 1
 
         if !has_key(s:option_list, token)
-            if token =~# '^-'
+            if token == '--'
+              let no_more_options = 1
+              continue
+            elseif token =~# '^-' && !no_more_options
                 call ctrlsf#log#Error("Unknown option '%s'. If you are user
                     \ from pre-v1.0, please be aware of that CtrlSF no longer
                     \ supports all options of ack and ag since v1.0. Read


### PR DESCRIPTION
Could not find a way to search for a string that started with a dash, for example `:CtrlSF -foo` so implemented the double dash option that's analogous to what's used by most commands, now you can search with `:CtrlSF -- -foo`. =)