### PR TITLE
#165 bdelete when last win (E444)

### DIFF
--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -99,12 +99,17 @@ func! ctrlsf#win#CloseMainWindow() abort
     endif
 
     " Surely we are in CtrlSF window
-    close
+    try
+      close
 
-    " restore width/height of other windows
-    call ctrlsf#win#RestoreAllWinSize()
+      " restore width/height of other windows
+      call ctrlsf#win#RestoreAllWinSize()
 
-    call ctrlsf#win#FocusCallerWindow()
+      call ctrlsf#win#FocusCallerWindow()
+    catch /^Vim\%((\a\+)\)\=:E444/
+      " This is the last window, simply delete the buffer
+      bdelete
+    endtry
 endf
 
 " ResizeNeighborWins()


### PR DESCRIPTION
This is a crude but simple way to cleanly detect when this is the last window, and then instead delete the buffer. 

It works fine on gvim on Windows and vim on Termux (both version 8), I still have to test this in Ubuntu with vim 7.3 (how far do you support vim?) I also didn't see any test suite, any expectations on testing? 

Should be otherwise pretty straightforward :) 