### PR TITLE
fix(bug): expand('%:p')

### DIFF
--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -169,6 +169,9 @@ func! ctrlsf#opt#GetPath() abort
             if empty(path)
                 if opt_fbroot ==# 'f'
                     let path = expand('%:p')
+                    if empty(path)
+                        let path = getcwd()
+                    endif
                 elseif opt_fbroot ==# 'w'
                     let path = getcwd()
                 endif


### PR DESCRIPTION
if backend is rg, when invoke vim without file arguments, then
expand('%:p') will return empty string '', but rg will fail.
FAIL:    usr/bin/rg -C 5  --smart-case --fixed-strings --no-heading --color never --line-number -- 'cstring' ''
SUCCESS: usr/bin/rg -C 5  --smart-case --fixed-strings --no-heading --color never --line-number -- 'cstring'