### PR TITLE
Add flag to search only for words

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ CtrlSF has a lot of arguments you can use in search. Most arguments are similar 
 - `-R` - Use regular expression pattern.
 - `-I`, `-S` - Search case-insensitively (`-I`) or case-sensitively (`-S`).
 - `-C`, `-A`, `-B` - Specify how many context lines to be printed, identical to their counterparts in Ag/Ack.
+- `-W` - Only match whole words.
 
 Read `:h ctrlsf-arguments` for a full list of arguments.
 

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -111,6 +111,10 @@ func! s:BuildCommand(args) abort
         endif
     endif
 
+    if !empty(ctrlsf#opt#GetOpt('word'))
+        call add(tokens, '-w')
+    endif
+
     " filematch (NOT SUPPORTED BY ALL BACKEND)
     " support backend: ag, ack, pt
     if !empty(ctrlsf#opt#GetOpt('filematch'))

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -11,6 +11,7 @@ let s:option_list = {
     \ '-before'     : {'args': 1},
     \ '-context'    : {'args': 1},
     \ '-filetype'   : {'args': 1},
+    \ '-word'       : {'args': 0},
     \ '-filematch'  : {'args': 1},
     \ '-ignorecase' : {'args': 0},
     \ '-ignoredir'  : {'args': 1},
@@ -26,6 +27,7 @@ let s:option_list = {
     \ '-L': {'fullname': '-literal'},
     \ '-R': {'fullname': '-regex'},
     \ '-S': {'fullname': '-matchcase'},
+    \ '-W': {'fullname': '-word'},
     \ }
 
 " default values to options

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -296,6 +296,12 @@ Make this search be case-sensitive.
 Use pattern as regular expression.
 >
     :CtrlSF -R foo.*
+
+'-word', '-W'                                               *ctrlsf_args_word*
+
+Search only for whole words.
+>
+    :CtrlSF -W foo
 <
 '-smartcase'                                           *ctrlsf_args_smartcase*
 


### PR DESCRIPTION
Hi, thanks for the great plugin!
Most of the backend engines have a flag option to search only for whole words (-w) instead of wrapping the regex in word boundaries.
Not sure if I missed something but I did not find a way to forward flags from ctrlsf to the backend, I just saw a way to hardcode them permanently.
So I though that having such flag would be a good addition. Let me know if I can improve this or update the docs.
