### PR TITLE
[WIP] Allow suffix in buffer maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,12 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
         \ }
     ```
 
-- `g:ctrlsf_mapping` defines maps used in result window and preview window. Value of this option is a dictionary, where key is a method and value is a key for mapping. An empty value can disable that method. You can just define a subset of full dictionary, those not defined functionalities will use default key mapping.
+
+- `g:ctrlsf_mapping` defines maps used in result window and preview window. Value of this option is a dictionary, where key is a method and value is a key for mapping. An empty value can disable that method. To specify additional keys to run after a method, use the extended form demonstrated below to specify a `suffix`. You can just define a subset of full dictionary, those not defined functionalities will use default key mapping.
 
     ```vim
     let g:ctrlsf_mapping = {
+        \ "openb": { key: "O", suffix: "<C-w>p" },
         \ "next": "n",
         \ "prev": "N",
         \ }

--- a/autoload/ctrlsf/utils.vim
+++ b/autoload/ctrlsf/utils.vim
@@ -43,6 +43,20 @@ func! ctrlsf#utils#Nmap(map, act_func_ref) abort
                     \ . " :call " . a:act_func_ref[act] . "<CR>"
             endfo
         endif
+
+        if type(a:map[act]) == 4
+            let m = a:map[act]
+            let suffix = has_key(m, 'suffix') ? m['suffix'] : ''
+            if type(m['key']) == 1
+                exec "silent! nnoremap <silent><buffer> " . m['key']
+                    \ . " :call " . a:act_func_ref[act] . "<CR>" . suffix
+            elseif type(m['key']) == 3
+                for key in m['key']
+                    exec "silent! nnoremap <silent><buffer> " . key
+                        \ . " :call " . a:act_func_ref[act] . "<CR>" . suffix
+                endfo
+            endif
+        endif
     endfo
 endf
 
@@ -62,6 +76,17 @@ func! ctrlsf#utils#Nunmap(map, act_func_ref) abort
             for key in a:map[act]
                 exec "nunmap <silent><buffer> " . key
             endfo
+        endif
+
+        if type(a:map[act]) == 4
+            let m = a:map[act]
+            if type(m['key']) == 1
+                exec "nunmap <silent><buffer> " . m['key']
+            elseif type(a:map[act]) == 3
+                for key in m['key']
+                    exec "nunmap <silent><buffer> " . key
+                endfo
+            endif
         endif
     endfo
 endf

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -467,9 +467,17 @@ Default:
         "chgmode" : "M",
     }
 <
+Sometimes you may wish for a method to also perform a complementary action such
+as scrolling the window, or returning focus to the CtrlSF window. In that case
+you can specify the method's value as a dictionary with a 'key' and a 'suffix',
+which contains the additional keys to execute after the method. In the following
+example, 'suffix' will return focus to the CtrlSF window after 'openb' is
+executed.
+
 Example:
 >
     let g:ctrlsf_mapping = {
+        \ "openb": { key: "O", suffix: "<C-w>p" },
         \ "next": "n",
         \ "prev": "N",
         \ "openb": "",


### PR DESCRIPTION
Allow passing suffix to ctrlsf buffer mappings. Useful for tasks like `zz` or `<C-w>p`. Eg:
```vimL
  let g:ctrlsf_mapping = {
        \ "open"    : ["<CR>", "o"],
        \ "openb"   : { "key": "O", "suffix": "<C-w>p" },
        \ "split"   : "<C-O>",
        \ "vsplit"  : "",
        \ "tab"     : "t",
        \ "tabb"    : "T",
        \ "popen"   : "p",
        \ "popenf"  : "P",
        \ "quit"    : "q",
        \ "next"    : "<C-J>",
        \ "prev"    : "<C-K>",
        \ "pquit"   : "q",
        \ "loclist" : "",
        \ "chgmode" : "M",
        \ }
```
Note this is fully backwards compatible with existing mappings. It merely adds the option to specify the value as: `{ "key": keyVal [, "suffix": suffixVal] }` where `keyVal` is a string or array, and `suffixVal` is a string.

Please let me know if this is something you'd be willing to merge so that I can update the docs.