### PR TITLE
vim-regex when magic is \v, '=' is no literally, should change to '\='

### DIFF
--- a/autoload/ctrlsf/pat.vim
+++ b/autoload/ctrlsf/pat.vim
@@ -41,13 +41,17 @@ func! s:TranslateRegex(pattern) abort
     " '\B' non-word boundary (just remove it)
     let pattern = substitute(pattern, '\C\\B', '', 'g')
 
+    " vim-regex when magic is \v, '=' is no literally, should change to '\='
+    let pattern = escape(pattern, '=')
+
     return pattern
 endf
 
 " Regex()
 "
 func! ctrlsf#pat#Regex() abort
-    let pattern = ctrlsf#opt#GetOpt('pattern')
+    let pattern     = ctrlsf#opt#GetOpt('pattern')
+    let isRegexMode = ctrlsf#opt#GetRegex()
 
     " ignore case
     let case_sensitive = ctrlsf#opt#GetCaseSensitive()
@@ -57,15 +61,14 @@ func! ctrlsf#pat#Regex() abort
     elseif case_sensitive ==# 'matchcase'
         let case = '\C'
     else "smartcase
-        let pat  = ctrlsf#opt#GetOpt('pattern')
-        let case = (pat =~# '\u') ? '\C' : '\c'
+        let case = (pattern =~# '\u') ? '\C' : '\c'
     endif
 
     " magic
-    let magic = ctrlsf#opt#GetRegex() ? '\v' : '\V'
+    let magic = isRegexMode ? '\v' : '\V'
 
     " literal
-    if ctrlsf#opt#GetRegex()
+    if isRegexMode
         let pattern = s:TranslateRegex(pattern)
     else
         let pattern = escape(pattern, '\')

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -255,7 +255,7 @@ alias for '-context'.
 '-filetype'                                             *ctrlsf_args_filetype*
 
 Defines which type of files should the search be restricted to. view
-`ack --help=typs` for all available types.
+`ack --help=types` for all available types.
 >
     :CtrlSF -filetype vim foo
 <


### PR DESCRIPTION
test code
======

 :echo match('aa=b=+b','\v=')
Fail
==
E866: (NFA regexp) Misplaced =
E64: = follows nothing

vim-regex when magic is \v, '=' is no literally, should change to '\='