### PR TITLE
vim-regex when magic is \v, '=' '&' is no literally, should change to '\=' and '\&'

### DIFF
--- a/autoload/ctrlsf/pat.vim
+++ b/autoload/ctrlsf/pat.vim
@@ -41,13 +41,17 @@ func! s:TranslateRegex(pattern) abort
     " '\B' non-word boundary (just remove it)
     let pattern = substitute(pattern, '\C\\B', '', 'g')
 
+    " vim-regex when magic is \v, '=' is no literally, should change to '\='
+    let pattern = escape(pattern, '=')
+
     return pattern
 endf
 
 " Regex()
 "
 func! ctrlsf#pat#Regex() abort
-    let pattern = ctrlsf#opt#GetOpt('pattern')
+    let pattern     = ctrlsf#opt#GetOpt('pattern')
+    let isRegexMode = ctrlsf#opt#GetRegex()
 
     " ignore case
     let case_sensitive = ctrlsf#opt#GetCaseSensitive()
@@ -57,15 +61,14 @@ func! ctrlsf#pat#Regex() abort
     elseif case_sensitive ==# 'matchcase'
         let case = '\C'
     else "smartcase
-        let pat  = ctrlsf#opt#GetOpt('pattern')
-        let case = (pat =~# '\u') ? '\C' : '\c'
+        let case = (pattern =~# '\u') ? '\C' : '\c'
     endif
 
     " magic
-    let magic = ctrlsf#opt#GetRegex() ? '\v' : '\V'
+    let magic = isRegexMode ? '\v' : '\V'
 
     " literal
-    if ctrlsf#opt#GetRegex()
+    if isRegexMode
         let pattern = s:TranslateRegex(pattern)
     else
         let pattern = escape(pattern, '\')

--- a/autoload/ctrlsf/pat.vim
+++ b/autoload/ctrlsf/pat.vim
@@ -41,8 +41,8 @@ func! s:TranslateRegex(pattern) abort
     " '\B' non-word boundary (just remove it)
     let pattern = substitute(pattern, '\C\\B', '', 'g')
 
-    " vim-regex when magic is \v, '=' is no literally, should change to '\='
-    let pattern = escape(pattern, '=')
+    " vim-regex when magic is \v, '=' '&' is no literally, should change to '\=' and '\&'
+    let pattern = escape(pattern, '=&')
 
     return pattern
 endf

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -255,7 +255,7 @@ alias for '-context'.
 '-filetype'                                             *ctrlsf_args_filetype*
 
 Defines which type of files should the search be restricted to. view
-`ack --help=typs` for all available types.
+`ack --help=types` for all available types.
 >
     :CtrlSF -filetype vim foo
 <


### PR DESCRIPTION
Preface
=====
I use rg as my backend, but ack backend has the same question.

1 test code
=======
I have a file name php.c, with this content in it.
```c
f.type = ZEND_OVERLOADED_FUNCTION
```
I try to find out '.type ='
and I use this Ex command to seach it, 
```vim
:CtrlSF -R \.type\s*=
```
BUT I get this error message
```vim
Error detected while processing function ctrlsf#Search[15]..<SNR>118_ExecSearch[23]..ctrlsf#db#ParseAckprgResult[44]..ctrlsf#class#paragraph#New[15]..ctrlsf#class#line#New:
line    1:
E871: (NFA regexp) Can't have a multi follow a multi !
E62: Nested =
```

1.1 error reproduce
---------------------
run this vim code
```vim
:echo match('f.type = ZEND_OVERLOADED_FUNCTION', '\v\.type\s*=')
```
,it will output the same error message
```vim
E871: (NFA regexp) Can't have a multi follow a multi !
E62: Nested =
-1
```
BUT this code run well
```vim
:echo match('f.type = ZEND_OVERLOADED_FUNCTION', '\v\.type\s*\=')
```

Reasion
--------
vim-regex when magic is \v, '=' is no literally, should change to '\\='

2 test code
=======
I have a file name php.c, with this content in it.
```c
mptr->common.fn_flags & ZEND_ACC_PROTECTED ? "protected" : "private"
```
I try to find out '& ZEND_ACC_PROTECTED'
and I use this Ex command to seach it, in the \_\_CtrlSF\_\_ window, ctrl+j did not work
```vim
:CtrlSF -R &\s*ZEND_ACC_PROTECTED 
```
Reasion
--------
vim-regex when magic is \v, '&' is no literally, should change to '\\&'