### PR TITLE
Hide line numbers when relativenumber is set

### DIFF
--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -138,6 +138,7 @@ func! s:InitMainWindow() abort
     setl nobuflisted
     setl nolist
     setl nonumber
+    setl norelativenumber
     setl nowrap
     setl winfixwidth
     setl winfixheight


### PR DESCRIPTION
I've had this little annoyance from the start because I have _relativenumbers_ enabled, so I've always seen two line numbers in every line in the CtrlSF window.

This PR disables the abovementioned option locally.