### PR TITLE
Add -G support for ripgrep

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -116,7 +116,7 @@ func! s:BuildCommand(args) abort
     endif
 
     " filematch (NOT SUPPORTED BY ALL BACKEND)
-    " support backend: ag, ack, pt
+    " support backend: ag, ack, pt, rg
     if !empty(ctrlsf#opt#GetOpt('filematch'))
         if runner ==# 'ag'
             call extend(tokens, [
@@ -125,6 +125,9 @@ func! s:BuildCommand(args) abort
                 \ ])
         elseif runner ==# 'pt'
             call add(tokens, printf("--file-search-regex=%s",
+                \ shellescape(ctrlsf#opt#GetOpt('filematch'))))
+        elseif runner ==# 'rg'
+            call add(tokens, printf("-g %s",
                 \ shellescape(ctrlsf#opt#GetOpt('filematch'))))
         elseif runner ==# 'ack'
             " pipe: 'ack -g ${filematch} ${path} |'

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -262,6 +262,7 @@ Defines which type of files should the search be restricted to. view
 '-filematch', '-G'                       *ctrlsf_args_G* *ctrlsf_args_filematch*
 
 Defines a pattern that only files whose name is matching will be searched.
+The pattern might depend on the backend being used.
 >
     :Ctrlsf -filematch .*\.wrproject foo
 <


### PR DESCRIPTION
Hey since sometimes the rg backend does not recognize certain filetypes and adding a file-type see [this](https://github.com/BurntSushi/ripgrep/issues/118) is such a pain (because aliases are not that easy to be picked by vim). I thought it would be good to add GLOB support for ripgrep too. The syntax however is a wildcard one not a regex.

e.g. `:CtrlSF -G *.pug svg` will find svg in all pug files.

Didn't want to put example in the docs not to confuse fresh users, however users with non-default backend will understand how to type it.

Hope this makes sense.

Regards,
Petur