### PR TITLE
.gitignore for swap, session, temp and generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags


### PR DESCRIPTION
After running `:Helptags` vim creates untracked `doc/tags`. Ignore the file.