### PR TITLE
Fix working with Ag

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -20,7 +20,7 @@ let s:backend_args_map = {
             \ '1': '',
             \ '0': '--literal'
             \ },
-        \ 'default': '--noheading --nogroup --nocolor --nobreak --filename'
+        \ 'default': '--noheading --nogroup --nocolor --nobreak'
         \ },
     \ 'ack': {
         \ 'ignorecase': {


### PR DESCRIPTION
Fix #195 .

### Reason

Ag's behavior differs from what is documented in its manual for
option '--filename', it does not print filename even '--filename' is
specified.

### Detail

With below command

```shell
$ ag -C 3 --smart-case --literal --noheading --nogroup --nocolor --nobreak --filename --follow -- 'foo' '.'
```

We get output like this

```
sample2
1:foo
2-bar
3-
sample1
1:foo
2-bar
3-
```

But what we need is

```
sample1:1:foo
sample1:2-bar
sample1:3-
sample2:1:foo
sample2:2-bar
sample2:3-
```