### PR TITLE
Fix no follow flag for ripgrep

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -74,7 +74,7 @@ let s:backend_args_map = {
             \ },
         \ 'follow': {
             \ '1': '--follow',
-            \ '0': '--nofollow'
+            \ '0': '--no-follow'
             \ },
         \ 'default': '--no-heading --color never --line-number -H'
         \ }


### PR DESCRIPTION
https://github.com/dyng/ctrlsf.vim/pull/251 introduced additional flags for enabling/disabling following symlinks. However there was a small mistake there: the flag for ripgrep is `--no-follow`.

Currently i see this:

```
Backend Failure. Error messages: error: Found argument '--nofollow' which wasn't expected, or isn't valid in this context                                                  
Backend Failure. Error messages: ^IDid you mean --no-follow?                                                                                                               
Backend Failure. Error messages:                                                                                                                                           
Backend Failure. Error messages: USAGE:                                                                                                                                    
Backend Failure. Error messages:                                                                                                                                           
Backend Failure. Error messages:     rg [OPTIONS] PATTERN [PATH ...]                                                                                                       
Backend Failure. Error messages:     rg [OPTIONS] [-e PATTERN ...] [-f PATTERNFILE ...] [PATH ...]                                                                         
Backend Failure. Error messages:     rg [OPTIONS] --files [PATH ...]                                                                                                       
Backend Failure. Error messages:     rg [OPTIONS] --type-list                                                                                                              
Backend Failure. Error messages:     command | rg [OPTIONS] PATTERN                                                                                                        
Backend Failure. Error messages:                                                                                                                                           
Backend Failure. Error messages: For more information try --help 
```

```
$ rg --help | grep -A 5 -- --follow
    -L, --follow                            
            When this flag is enabled, ripgrep will follow symbolic links while traversing
            directories. This is disabled by default. Note that ripgrep will check for
            symbolic link loops and report errors if it finds one.
            
            This flag can be disabled with --no-follow.
```

This PR fixes that flag so ripgrep works again.