### PR TITLE
Set 'g:ctrlsf_follow_symlinks' by default

### DIFF
--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -476,10 +476,10 @@ project root.
     let g:ctrlsf_extra_root_markers = ['.root']
 <
 g:ctrlsf_follow_symlinks                            *'g:ctrlsf_follow_symlinks'*
-Default: 0
+Default: 1
 Defines whether the backend should follow symbolic links or not.
 >
-    let g:ctrlsf_follow_symlinks = 1
+    let g:ctrlsf_follow_symlinks = 0
 <
 g:ctrlsf_ignore_dir                                      *'g:ctrlsf_ignore_dir'*
 Default: ''

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -170,7 +170,7 @@ endif
 
 " g:ctrlsf_follow_symlinks {{{2
 if !exists('g:ctrlsf_follow_symlinks')
-    let g:ctrlsf_follow_symlinks = 0
+    let g:ctrlsf_follow_symlinks = 1
 endif
 " }}}
 


### PR DESCRIPTION
I think it's better to set `g:ctrlsf_follow_symlinks` by default, because many modern backend such as `rg` does so.