### PR TITLE
Fix corrupted filename error

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -37,7 +37,6 @@ func! s:ExecSearch(args) abort
     else
         call s:DoSearchAsync(a:args)
     endif
-
 endf
 
 " s:Reset()
@@ -124,6 +123,11 @@ func! ctrlsf#SelfCheck() abort
                 \ && (v:version < 800 || (v:version == 800 && !has('patch1039')))
         call ctrlsf#log#Error('Asynchronous searching is not supported for your Vim.
                     \ Please make sure you are using Vim 8.0.1039+ or NeoVim.')
+        return -3
+    endif
+
+    if g:ctrlsf_indent < 2
+        call ctrlsf#log#Error("g:ctrlsf_indent can't be less than 2.")
         return -3
     endif
 endf

--- a/autoload/ctrlsf/edit.vim
+++ b/autoload/ctrlsf/edit.vim
@@ -183,6 +183,7 @@ func! ctrlsf#edit#Save() abort
     let orig = ctrlsf#db#FileResultSet()
     let rs   = ctrlsf#view#Unrender(getline(0, '$'))
     let modi = ctrlsf#db#FileResultSetBy(rs)
+    call ctrlsf#log#Debug("UnrenderedResultSet: %s", rs)
 
     " check difference and validity
     try

--- a/autoload/ctrlsf/view.vim
+++ b/autoload/ctrlsf/view.vim
@@ -311,7 +311,7 @@ func! ctrlsf#view#Unrender(content) abort
 
             if line ==# '....' || line ==# ''
                 break
-            elseif line !~ '\v^\d+[:-]'
+            elseif line !~ '\v^\d+[:-]\s{2,}'
                 " strip trailing colon
                 let next_file = substitute(line, ':$', '', '')
                 break

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -494,7 +494,8 @@ that does not respect to '.gitignore'.
 g:ctrlsf_indent                                              *'g:ctrlsf_indent'*
 Default: 4
 Defines how many spaces are placed between line number and line content. You
-can set a sane small value for more compact view.
+can set a sane small value for more compact view, but the value can't be less
+than 2.
 >
     let g:ctrlsf_indent = 2
 <


### PR DESCRIPTION
A file whose name starts with number can't be recognized as a normal
Filename, then InconsistentException is raised. Fix #269 .