### PR TITLE
Indicate nothing found in compact mode

### DIFF
--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -106,6 +106,14 @@ func! ctrlsf#win#DrawIncr() abort
         if s:drawn_lines == 0
             let s:drawn_lines = 1
         endif
+    else
+      if ctrlsf#async#IsSearchDone() && empty(ctrlsf#db#ResultSet())
+        silent! undojoin | keepjumps call ctrlsf#buf#WriteString("Nothing found!")
+      endif
+
+      if ctrlsf#async#IsCancelled() && empty(ctrlsf#db#ResultSet())
+        silent! undojoin | keepjumps call ctrlsf#buf#WriteString("Cancelled.")
+      endif
     endif
 
     let new_lines = ctrlsf#view#RenderIncr()


### PR DESCRIPTION
With `g:ctrlsf_default_view_mode = 'compact'` if a search turns up with
no results the "Searching..." text will still be displayed in the
results window.

This commit makes it so that "Nothing found!" is shown instead.


**Before**
<img width="264" alt="__CtrlSF___-____Code_rc_vim_bundle_ctrlsf_vim__-_NVIM_and_Indicate_nothing_found_in_compact_mode_by_shanesmith_·_Pull_Request__279_·_dyng_ctrlsf_vim_-_Vivaldi" src="https://user-images.githubusercontent.com/348425/67650616-13e5cc00-f914-11e9-8b59-5431e21f569a.png">

**After**
<img width="259" alt="__CtrlSF___-____Code_neovim__-_NVIM" src="https://user-images.githubusercontent.com/348425/67650665-41327a00-f914-11e9-9186-daa37220ebaf.png">

