### PR TITLE
Introduce -hidden argument to search hidden files and directories

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -170,6 +170,14 @@ func! s:BuildCommand(args, for_shell) abort
     call add(tokens,
         \ s:backend_args_map[runner]['follow'][g:ctrlsf_follow_symlinks])
 
+    " search hidden files (NOT SUPPORTED BY ALL BACKEND)
+    " support backend: ag, rg, pt
+    if !empty(ctrlsf#opt#GetOpt('hidden'))
+      if runner !=# 'ack'
+        call add(tokens, "--hidden")
+      endif
+    endif
+
     " default
     call add(tokens,
         \ s:backend_args_map[runner]['default'])

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -19,6 +19,7 @@ let s:option_list = {
     \ '-matchcase'  : {'args': 0},
     \ '-regex'      : {'args': 0},
     \ '-smartcase'  : {'args': 0},
+    \ '-hidden'     : {'args': 0},
     \ '-A': {'fullname': '-after'},
     \ '-B': {'fullname': '-before'},
     \ '-C': {'fullname': '-context'},

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -293,6 +293,12 @@ here is '--ignore' for ag and '--ignore-dir' for ack.
 >
     :CtrlSF -ignoredir "bower_components" 'console.log'
 <
+'-hidden'                                                 *ctrlsf_args_hidden*
+
+Search hidden files and directories.
+>
+    :CtrlSF -hidden foo
+<
 '-literal', '-L'                           *ctrlsf_args_L* *ctrlsf_args_literal*
 
 Use pattern as literal string.


### PR DESCRIPTION
By default rg, ag and pt exclude hidden files and directories, this
introduces a new -hidden argument to include them.