### PR TITLE
Fix async timer doesn't end

### DIFF
--- a/autoload/ctrlsf/async.vim
+++ b/autoload/ctrlsf/async.vim
@@ -36,6 +36,8 @@ endf
 " Reset()
 "
 func! ctrlsf#async#Reset() abort
+    call ctrlsf#async#ForceStopSearch()
+
     let s:job_id = -1
     let s:timer_id = -1
     let s:done = -1
@@ -114,13 +116,7 @@ endf
 "
 func! ctrlsf#async#StopSearch() abort
     call ctrlsf#log#Debug("StopSearch")
-    if type(s:job_id) != type(-1)
-        if has('nvim')
-            call jobstop(s:job_id)
-        else
-            call job_stop(s:job_id, "int")
-        endif
-    endif
+    call s:StopJob()
     if ctrlsf#async#IsSearching()
         call s:DiscardResult()
         let s:cancelled = 1
@@ -198,9 +194,15 @@ endf
 " StopParse()
 "
 func! ctrlsf#async#StopParse() abort
-    call ctrlsf#log#Debug("StopTimer: id=%s", s:timer_id)
-    call timer_stop(s:timer_id)
+    call s:StopTimer()
 endf
+
+" ForceStopSearch()
+"
+func! ctrlsf#async#ForceStopSearch() abort
+  call s:StopJob()
+  call s:StopTimer()
+endfunc
 
 " SearchDone()
 "
@@ -227,4 +229,24 @@ func! s:SearchDone() abort
     endif
 
     call ctrlsf#log#Debug("ParseFinish")
+endf
+
+" StopJob()
+"
+func! s:StopJob() abort
+    call ctrlsf#log#Debug("StopJob")
+    if type(s:job_id) != type(-1)
+        if has('nvim')
+            call jobstop(s:job_id)
+        else
+            call job_stop(s:job_id, "int")
+        endif
+    endif
+endfunc
+
+" StopTimer()
+"
+func! s:StopTimer() abort
+  call ctrlsf#log#Debug("StopTimer: id=%s", s:timer_id)
+  call timer_stop(s:timer_id)
 endf


### PR DESCRIPTION
An issue exists where the timer id of an running async search is lost
if a new search is performed resulting in the timer never ending.

Here we make sure to cover multiple scenarios so that we don't lose a
timer.