### PR TITLE
Add auto_preview option

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
         \ }
     ```
 
+- `g:ctrlsf_auto_preview` defines whether CtrlSF shows the preview window automatically while moving from match to match in the results pane. The default value is 0.
+
+    ```vim
+    let g:ctrlsf_auto_preview = 1
+    ```
+
 - `g:ctrlsf_case_sensitive` defines default case-sensitivity in search. Possible values are `yes`, `no` and `smart`, `smart` works the same as it is in vim. The default value is `smart`.
 
     ```vim

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -358,6 +358,9 @@ func! ctrlsf#NextMatch(forward) abort
         endif
 
         call cursor(vlnum, vcol)
+        if g:ctrlsf_auto_preview
+            call ctrlsf#JumpTo('preview')
+        endif
     endif
 endf
 

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -388,6 +388,13 @@ Example:
         \ "duration_less_than": 1000
         \ }
 <
+g:ctrlsf_auto_preview                                  *'g:ctrlsf_auto_preview'*
+Default: 0
+Defines whether CtrlSF shows the preview window automatically while moving from
+match to match in the results pane.
+>
+    let g:ctrlsf_auto_preview = 1
+<
 g:ctrlsf_case_sensitive                              *'g:ctrlsf_case_sensitive'*
 Default: 'smart'
 Available: 'smart', 'yes', 'no'

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -114,6 +114,12 @@ else
 endif
 " }}}
 
+" g:ctrlsf_auto_preview {{{2
+if !exists('g:ctrlsf_auto_preview')
+    let g:ctrlsf_auto_preview = 0
+endif
+" }}}
+
 " g:ctrlsf_case_sensitive {{{2
 if !exists('g:ctrlsf_case_sensitive')
     let g:ctrlsf_case_sensitive = 'smart'


### PR DESCRIPTION
I added an extra option, `g:ctrlsf_auto_preview` to enable auto-previewing while navigating in the
results pane. The default is 0, which doesn't modify the original behavior.