### PR TITLE
Add '-T' shortcut for '-filetype'

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
 
 - By default, CtrlSF use working directory as search path when no path is specified. But CtrlSF can also use project root as its path if you set `g:ctrlsf_default_root` to `project`, CtrlSF does this by searching VCS directory (.git, .hg, etc.) upward from current file. It is useful when you are working with files across multiple projects.
 
-- `-filetype` is useful when you only want to search in files of specific type. Read option `--type` in `ack`'s [manual][6] for more information.
+- `-filetype` is useful when you only want to search in files of specific type. Read option `--type` in `ack`'s [manual][6] for more information. Also, a shortcut `-T` is available.
 
 - If `-filetype` does not exactly match your need, there is an option `-filematch` with which you have more control on which files should be searched. `-filematch` accepts a pattern that only files match this pattern will be searched. Note the pattern is in syntax of your backend but not vim's. Also, a shortcut `-G` is available.
 

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -28,6 +28,7 @@ let s:option_list = {
     \ '-L': {'fullname': '-literal'},
     \ '-R': {'fullname': '-regex'},
     \ '-S': {'fullname': '-matchcase'},
+    \ '-T': {'fullname': '-filetype'},
     \ '-W': {'fullname': '-word'},
     \ }
 

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -265,9 +265,9 @@ alias for '-context'.
 >
     :CtrlSF -C 0 foo
 <
-'-filetype'                                             *ctrlsf_args_filetype*
+'-filetype', '-T'                                       *ctrlsf_args_filetype*
 
-Defines which type of files should the search be restricted to. view
+Defines which type of files should the search be restricted to. View
 `ack --help=types` for all available types.
 >
     :CtrlSF -filetype vim foo


### PR DESCRIPTION
As almost all commonly used arguments have shortcuts,
let's add a shortcut for '-filetype' as well.