### PR TITLE
Introduce g:ctrlsf_compact_winsize config variable

### DIFF
--- a/autoload/ctrlsf/preview.vim
+++ b/autoload/ctrlsf/preview.vim
@@ -38,7 +38,7 @@ func! ctrlsf#preview#OpenPreviewWindow() abort
                 \[g:ctrlsf_position] . ' '
     else
         " compact mode
-        let winsize = &lines - 20
+        let winsize = &lines - winheight(0) - 10
         let openpos = 'leftabove'
     endif
 

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -70,8 +70,13 @@ func! ctrlsf#win#OpenMainWindow() abort
               \ 'bottom' : 'botright', 'right' : 'botright vertical'}
               \[g:ctrlsf_position] . ' '
     else
-        " compact mode: fixed window size and position
-        let winsize = 10
+        if g:ctrlsf_compact_winsize =~ '\d\{1,2}%'
+            let winsize = &lines * str2nr(g:ctrlsf_compact_winsize) / 100
+        elseif g:ctrlsf_compact_winsize =~ '\d\+'
+            let winsize = str2nr(g:ctrlsf_compact_winsize)
+        else
+            let winsize = &lines / 2
+        endif
         let openpos = 'botright'
     endif
 

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -430,6 +430,20 @@ as its counterpart in Ag/Ack.
 >
     let g:ctrlsf_context = '-B 5 -A 3'
 <
+g:ctrlsf_compact_winsize                             *'g:ctrlsf_compact_winsize'*
+Default: '10'
+Available: 'auto', 'xx%', 'xx'
+Height of CtrlSF compact window. It accepts a string as its value and there are
+3 types of argument:
+>
+    'auto' : half of current vim window height.
+    'xx%'  : xx percent of current vim window size.
+    'xx'   : absolute size in characters.
+<
+Example:
+>
+    let g:ctrlsf_compact_winsize = '20%'
+<
 g:ctrlsf_debug_mode                                      *'g:ctrlsf_debug_mode'*
 Default: 0
 Verbose informations will be printed if you turn this option on. It's useful
@@ -638,7 +652,7 @@ this value is empty, means no key is mapped for this feature.
 >
     let g:ctrlsf_toggle_map_key = '\t'
 <
-g:ctrlsf_winsize                                                *'g:ctrlsf_width'*
+g:ctrlsf_winsize                                              *'g:ctrlsf_winsize'*
 Default: 'auto'
 Available: 'auto', 'xx%', 'xx'
 Size of CtrlSF window. This is its width if the window opens vertically (to the

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -288,6 +288,12 @@ if !exists('g:ctrlsf_winsize')
     let g:ctrlsf_winsize = 'auto'
 endif
 " }}}
+
+" g:ctrlsf_compact_winsize {{{2
+if !exists('g:ctrlsf_compact_winsize')
+    let g:ctrlsf_compact_winsize = '10'
+endif
+" }}}
 " }}}
 
 " Commands {{{1


### PR DESCRIPTION
The g:ctrlsf_winsize variable only controls the non-compact CtrlSF,
therefore a new g:ctrlsf_compact_winsize config is introduced to control
the compact window in much the same way.