### PR TITLE
Fix ctrlsf_extra_root_markers

### DIFF
--- a/autoload/ctrlsf/fs.vim
+++ b/autoload/ctrlsf/fs.vim
@@ -17,9 +17,14 @@ func! ctrlsf#fs#FindProjectRoot(...) abort
         let start_dir = expand('%:p:h')
     endif
 
-    let markers = g:ctrlsf_extra_root_markers + s:vcs_marker
+    if len(g:ctrlsf_extra_root_markers) > 0
+        let marker = s:FindMarker(start_dir, g:ctrlsf_extra_root_markers)
+    endif
 
-    let marker = s:FindMarker(start_dir, markers)
+    if empty(marker)
+        let marker = s:FindMarker(start_dir, s:vcs_marker)
+    endif
+
     let root = empty(marker) ? '' : fnamemodify(marker, ':h')
     call ctrlsf#log#Debug("ProjectRoot: %s", root)
 


### PR DESCRIPTION
In case when ctrlsf_extra_root_markers is higher in the directories hierarhy,
than any of vcs_markers, the search will be stopped earlier at one of vcs_marker.

This fix forces to do search by ctrlsf_extra_root_markers first and then
try vcs_markers if no root folder found.