### PR TITLE
fix: undefined marker throw error message

### DIFF
--- a/autoload/ctrlsf/fs.vim
+++ b/autoload/ctrlsf/fs.vim
@@ -17,6 +17,7 @@ func! ctrlsf#fs#FindProjectRoot(...) abort
         let start_dir = expand('%:p:h')
     endif
 
+    let marker = []
     if len(g:ctrlsf_extra_root_markers) > 0
         let marker = s:FindMarker(start_dir, g:ctrlsf_extra_root_markers)
     endif


### PR DESCRIPTION
caused by https://github.com/dyng/ctrlsf.vim/pull/303