### PR TITLE
Add "local" window position options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,16 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
     let g:ctrlsf_search_mode = 'async'
     ```
 
-- `g:ctrlsf_position` defines where CtrlSf places its window. Possible values are `left`, `left_local`, `right`, `right_local`, `top` and `bottom`. If nothing specified, the default value is `left`.
+- `g:ctrlsf_position` defines where CtrlSf places its window in normal view mode. Possible values are `left`, `left_local`, `right`, `right_local`, `top` and `bottom`. If nothing specified, the default value is `left`.
 
     ```vim
     let g:ctrlsf_position = 'bottom'
+    ```
+
+- `g:ctrlsf_compact_position` defines where CtrlSf places its window in compact view mode. Possible values are `bottom_inside`, `bottom_outside`, `top_inside`, and `top_outside`. If nothing specified, the default value is `bottom_outside`.
+
+    ```vim
+    let g:ctrlsf_position = 'bottom_inside'
     ```
 
 - `g:ctrlsf_winsize` defines the width (if CtrlSF opens vertically) or height (if CtrlSF opens horizontally) of CtrlSF main window. You can specify it with percent value or absolute value.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Read `:h ctrlsf-arguments` for a full list of arguments.
     let g:ctrlsf_search_mode = 'async'
     ```
 
-- `g:ctrlsf_position` defines where CtrlSf places its window. Possible values are `left`, `right`, `top` and `bottom`. If nothing specified, the default value is `left`.
+- `g:ctrlsf_position` defines where CtrlSf places its window. Possible values are `left`, `left_local`, `right`, `right_local`, `top` and `bottom`. If nothing specified, the default value is `left`.
 
     ```vim
     let g:ctrlsf_position = 'bottom'

--- a/autoload/ctrlsf/preview.vim
+++ b/autoload/ctrlsf/preview.vim
@@ -25,18 +25,24 @@ func! ctrlsf#preview#OpenPreviewWindow() abort
     if vmode ==# 'normal'
         " normal mode
         if g:ctrlsf_preview_position == 'inside'
-            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right" ||
+             \ g:ctrlsf_position == 'left_local' || g:ctrlsf_position == 'right_local'
                 let winsize = winheight(0) / 2
             else
                 let winsize = winwidth(0) / 2
             endif
 
             let openpos = {
-                    \ 'bottom': 'rightbelow vertical',  'right' : 'rightbelow',
-                    \ 'top'   : 'rightbelow vertical',  'left' : 'rightbelow'}
+                    \ 'bottom': 'rightbelow vertical',
+                    \ 'right' : 'rightbelow',
+                    \ 'right_local' : 'rightbelow',
+                    \ 'top'   : 'rightbelow vertical',
+                    \ 'left' : 'rightbelow',
+                    \ 'left_local' : 'rightbelow'}
                     \[g:ctrlsf_position] . ' '
         else
-            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right" ||
+             \ g:ctrlsf_position == 'left_local' || g:ctrlsf_position == 'right_local'
                 let ctrlsf_width  = winwidth(0)
                 let winsize = min([&columns-ctrlsf_width, ctrlsf_width])
             else
@@ -45,8 +51,12 @@ func! ctrlsf#preview#OpenPreviewWindow() abort
             endif
 
             let openpos = {
-                    \ 'bottom': 'leftabove',  'right' : 'leftabove vertical',
-                    \ 'top'   : 'rightbelow',  'left' : 'rightbelow vertical'}
+                    \ 'bottom'      : 'leftabove',
+                    \ 'right'       : 'leftabove vertical',
+                    \ 'right_local' : 'leftabove vertical',
+                    \ 'top'         : 'rightbelow',
+                    \ 'left'        : 'rightbelow vertical',
+                    \ 'left_local'  : 'rightbelow vertical'}
                     \[g:ctrlsf_position] . ' '
         endif
     else

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -50,7 +50,8 @@ func! ctrlsf#win#OpenMainWindow() abort
     if vmode ==# 'normal'
         " normal mode
         if g:ctrlsf_winsize =~ '\d\{1,2}%'
-            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right" ||
+             \ g:ctrlsf_position == 'left_local' || g:ctrlsf_position == 'right_local'
                 let winsize = &columns * str2nr(g:ctrlsf_winsize) / 100
             else
                 let winsize = &lines * str2nr(g:ctrlsf_winsize) / 100
@@ -58,7 +59,8 @@ func! ctrlsf#win#OpenMainWindow() abort
         elseif g:ctrlsf_winsize =~ '\d\+'
             let winsize = str2nr(g:ctrlsf_winsize)
         else
-            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right"
+            if g:ctrlsf_position == "left" || g:ctrlsf_position == "right" ||
+             \ g:ctrlsf_position == 'left_local' || g:ctrlsf_position == 'right_local'
                 let winsize = &columns / 2
             else
                 let winsize = &lines / 2
@@ -66,8 +68,12 @@ func! ctrlsf#win#OpenMainWindow() abort
         endif
 
         let openpos = {
-              \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
-              \ 'bottom' : 'botright', 'right' : 'botright vertical'}
+              \ 'top'         : 'topleft',
+              \ 'left'        : 'topleft vertical',
+              \ 'left_local'  : 'leftabove vertical',
+              \ 'bottom'      : 'botright',
+              \ 'right'       : 'botright vertical',
+              \ 'right_local' : 'rightbelow vertical'}
               \[g:ctrlsf_position] . ' '
     else
         if g:ctrlsf_compact_winsize =~ '\d\{1,2}%'

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -83,7 +83,12 @@ func! ctrlsf#win#OpenMainWindow() abort
         else
             let winsize = &lines / 2
         endif
-        let openpos = 'botright'
+        let openpos = {
+              \ 'bottom_outside': 'botright',
+              \ 'bottom_inside': 'rightbelow',
+              \ 'top_outside': 'topleft',
+              \ 'top_inside': 'leftabove',
+              \ }[g:ctrlsf_compact_position]
     endif
 
 

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -617,6 +617,19 @@ be opened adjacent to the current window instead of at the edge of the tabpage.
 >
     let g:ctrlsf_position = 'bottom'
 <
+g:ctrlsf_compact_position                           *'g:ctrlsf_compact_position'*
+Default: 'bottom_outside'
+Available: 'bottom_inside', 'bottom_outside', 'top_inside', 'top_outside'
+Defines where CtrlSF places the main window when opened in 'compact' view
+(`g:ctrlsf_default_view_mode`). 'bottom_outside' and 'top_outside' open the
+CtrlSF window at the bottom or top of the tabpage respectively, so that the window
+takes up the entire width of the screen. 'bottom_inside' and 'top_inside' open
+the compact view inside the current vertical split, so that the width of the
+CtrlSF window is the same as the width of the current split. This option has
+no effect in `normal` view mode.
+>
+    let g:ctrlsf_compact_position = 'bottom_inside'
+<
 g:ctrlsf_preview_position                           *'g:ctrlsf_preview_position'*
 Default: 'outside'
 Available: 'inside', 'outside'

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -609,9 +609,11 @@ If you are used to vim builtin quickfix list and want to use |:cnext|,
 <
 g:ctrlsf_position                                          *'g:ctrlsf_position'*
 Default: 'left'
-Available: 'left', 'right', 'top', 'bottom'
-By default CtrlSF window will be opened at left. You can also specify for it to
-be opened 'top', 'right', or 'bottom'. E.g.:
+Available: 'left', 'left_local', 'right', 'right_local', 'top', 'bottom'
+By default CtrlSF window will be opened in a new split on the left edge of the
+tabpage. You can also specify for it to be opened 'left_local', top', 'right',
+'right_local' or 'bottom'. 'left_local' and 'right_local' cause the window to
+be opened adjacent to the current window instead of at the edge of the tabpage.
 >
     let g:ctrlsf_position = 'bottom'
 <

--- a/plugin/ctrlsf.vim
+++ b/plugin/ctrlsf.vim
@@ -142,6 +142,12 @@ if !exists('g:ctrlsf_confirm_unsaving_quit')
 endif
 " }}}
 
+" g:ctrlsf_compact_position {{{2
+if !exists('g:ctrlsf_compact_position')
+    let g:ctrlsf_compact_position = 'bottom_outside'
+endif
+" }}}
+
 " g:ctrlsf_context {{{2
 if !exists('g:ctrlsf_context')
     let g:ctrlsf_context = '-C 3'


### PR DESCRIPTION
This commit adds "left_local" and "right_local" as additional settings
for `g:ctrlsf_position`. These settings work like "left" and "right"
except that they open the CtrlSF window adjacent to the current window,
rather than on the edge of the tabpage. The commit also adds
documentation.