### PR TITLE
Window close hook

### DIFF
--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -156,6 +156,11 @@ func! ctrlsf#win#CloseMainWindow() abort
       call ctrlsf#win#RestoreAllWinSize()
 
       call ctrlsf#win#FocusCallerWindow()
+
+      " hook for user customization
+      if exists("*g:CtrlSFAfterMainWindowClose")
+        silent! call g:CtrlSFAfterMainWindowClose()
+      end
     catch /^Vim\%((\a\+)\)\=:E444/
       " This is the last window, simply delete the buffer
       bdelete

--- a/autoload/ctrlsf/win.vim
+++ b/autoload/ctrlsf/win.vim
@@ -185,6 +185,11 @@ endf
 
 " InitMainWindow()
 func! s:InitMainWindow() abort
+    " hook for user customization
+    if exists("*g:CtrlSFAfterMainWindowInit")
+        silent! call g:CtrlSFAfterMainWindowInit()
+    end
+
     if exists("b:ctrlsf_initialized")
         return
     endif
@@ -228,11 +233,6 @@ func! s:InitMainWindow() abort
         au BufWriteCmd         <buffer> call ctrlsf#Save()
         au BufHidden,BufUnload <buffer> call s:UndoAllChanges()
     augroup END
-
-    " hook for user customization
-    if exists("*g:CtrlSFAfterMainWindowInit")
-        silent! call g:CtrlSFAfterMainWindowInit()
-    end
 
     let b:ctrlsf_initialized = 1
 endf

--- a/doc/ctrlsf.txt
+++ b/doc/ctrlsf.txt
@@ -684,6 +684,15 @@ window initialized. It can be used to override default window setting.
     function! g:CtrlSFAfterMainWindowInit()
         setl wrap
     endfunction
+
+g:CtrlSFAfterMainWindowClose                     *'g:CtrlSFAfterMainWindowClose'*
+Default: None
+'g:CtrlSFAfterMainWindowClose' defines a function will be called after CtrlSF
+window closed. It can be used to override default window setting.
+>
+    function! g:CtrlSFAfterMainWindowClose()
+        setl nowrap
+    endfunction
 <
 ================================================================================
 7. About                                                          *ctrlsf-about*


### PR DESCRIPTION
There is CtrlSFAfterMainWindowInit hook, where different settings can be set, and commands run. But there is no way to revert these settings, i think it would be useful to have that option. 

Example:
```
function! g:CtrlSFAfterMainWindowInit()
  exe ':SexyScrollerToggle'
  set wrap
endfunction
function! g:CtrlSFAfterMainWindowClose()
  exe ':SexyScrollerToggle'
  set nowrap
endfunction
```