### PR TITLE
fix  dos new line escape

### DIFF
--- a/autoload/ctrlsf/class/line.vim
+++ b/autoload/ctrlsf/class/line.vim
@@ -18,7 +18,7 @@ func! ctrlsf#class#line#New(fname, lnum, content) abort
     return {
         \ 'lnum'      : a:lnum,
         \ 'vpos'      : {'normal':{'lnum':-1}},
-        \ 'content'   : a:content,
+        \ 'content'   : substitute(a:content, "\r$", "", ""),
         \ 'match'     : match,
         \ 'matched'   : function("ctrlsf#class#line#Matched"),
         \ 'vlnum'     : function('ctrlsf#class#line#Vlnum'),


### PR DESCRIPTION
fixes: https://github.com/dyng/ctrlsf.vim/issues/299
hopefully without affecting vanilla vim.