### PR TITLE
Use the working folder of the search to used it to open the result file.

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -426,21 +426,28 @@ func! s:OpenFileInWindow(file, lnum, col, mode, split) abort
         endif
     endif
 
+    let file_path = ''
+    if isabsolutepath(a:file)
+      let file_path = a:file
+    else
+      let file_path = g:ctrlsf_pwd . '/' . a:file
+    endif
+
     let target_winnr = ctrlsf#win#FindTargetWindow(a:file)
     if target_winnr == 0
-        exec 'silent split ' . fnameescape(a:file)
+        exec 'silent split ' . fnameescape(file_path)
     else
         exec target_winnr . 'wincmd w'
 
         if bufname('%') !=# a:file
             if a:split || (&modified && !&hidden)
                 if a:split == 2
-                    exec 'silent vertical split ' . fnameescape(a:file)
+                    exec 'silent vertical split ' . fnameescape(file_path)
                 else
-                    exec 'silent split ' . fnameescape(a:file)
+                    exec 'silent split ' . fnameescape(file_path)
                 endif
             else
-                exec 'silent edit ' . fnameescape(a:file)
+                exec 'silent edit ' . fnameescape(file_path)
             endif
         endif
     endif

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -83,6 +83,7 @@ let s:backend_args_map = {
 " BuildCommand()
 "
 func! s:BuildCommand(args, for_shell) abort
+    let g:ctrlsf_pwd = getcwd()
     let tokens = []
     let runner = ctrlsf#backend#Runner()
 


### PR DESCRIPTION
This pull request intent to solve issue #344:

Fail to open the file of the search result when the working directory change