### PR TITLE
Allow multiple -G options in the same request

### DIFF
--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -147,30 +147,33 @@ func! s:BuildCommand(args, for_shell) abort
     " filematch (NOT SUPPORTED BY ALL BACKEND)
     " support backend: ag, ack, pt, rg
     if !empty(ctrlsf#opt#GetOpt('filematch'))
-        if runner ==# 'ag'
-            call extend(tokens, [
-                \ '--file-search-regex',
-                \ s:Escape(a:for_shell, ctrlsf#opt#GetOpt('filematch'))
-                \ ])
-        elseif runner ==# 'pt'
-            call add(tokens, printf("--file-search-regex=%s",
-                        \ s:Escape(a:for_shell, ctrlsf#opt#GetOpt('filematch'))))
-        elseif runner ==# 'rg'
-            call add(tokens, printf("-g %s",
-                        \ s:Escape(a:for_shell, ctrlsf#opt#GetOpt('filematch'))))
-        elseif runner ==# 'ack'
-            " pipe: 'ack -g ${filematch} ${path} |'
-            let pipe_tokens = [
-                \ g:ctrlsf_backend,
-                \ '-g',
-                \ s:Escape(a:for_shell, ctrlsf#opt#GetOpt('filematch'))
-                \ ]
-            call extend(pipe_tokens, ctrlsf#opt#GetPath())
-            call add(pipe_tokens, '|')
+        let filematches = ctrlsf#opt#GetOpt('filematch')
+        for filematch in filematches
+          if runner ==# 'ag'
+              call extend(tokens, [
+                  \ '--file-search-regex',
+                  \ s:Escape(a:for_shell, filematch)
+                  \ ])
+          elseif runner ==# 'pt'
+              call add(tokens, printf("--file-search-regex=%s",
+                          \ s:Escape(a:for_shell, filematch)))
+          elseif runner ==# 'rg'
+              call add(tokens, printf("-g %s",
+                          \ s:Escape(a:for_shell, filematch)))
+          elseif runner ==# 'ack'
+              " pipe: 'ack -g ${filematch} ${path} |'
+              let pipe_tokens = [
+                  \ g:ctrlsf_backend,
+                  \ '-g',
+                  \ s:Escape(a:for_shell, filematch)
+                  \ ]
+              call extend(pipe_tokens, ctrlsf#opt#GetPath())
+              call add(pipe_tokens, '|')
 
-            call insert(tokens, join(pipe_tokens, ' '))
-            call add(tokens, '--files-from=-')
-        endif
+              call insert(tokens, join(pipe_tokens, ' '))
+              call add(tokens, '--files-from=-')
+          endif
+        endfor
     endif
 
     " follow symlink

--- a/autoload/ctrlsf/opt.vim
+++ b/autoload/ctrlsf/opt.vim
@@ -7,20 +7,20 @@
 
 " option list of CtrlSF
 let s:option_list = {
-    \ '-after'      : {'args': 1},
-    \ '-before'     : {'args': 1},
-    \ '-context'    : {'args': 1},
-    \ '-filetype'   : {'args': 1},
-    \ '-word'       : {'args': 0},
-    \ '-filematch'  : {'args': 1},
-    \ '-ignorecase' : {'args': 0},
-    \ '-ignoredir'  : {'args': 1},
-    \ '-literal'    : {'args': 0},
-    \ '-matchcase'  : {'args': 0},
-    \ '-regex'      : {'args': 0},
-    \ '-smartcase'  : {'args': 0},
-    \ '-hidden'     : {'args': 0},
-    \ '-encoding'   : {'args': 1},
+    \ '-after'      : {'args': '1'},
+    \ '-before'     : {'args': '1'},
+    \ '-context'    : {'args': '1'},
+    \ '-filetype'   : {'args': '1'},
+    \ '-word'       : {'args': '0'},
+    \ '-filematch'  : {'args': '*'},
+    \ '-ignorecase' : {'args': '0'},
+    \ '-ignoredir'  : {'args': '1'},
+    \ '-literal'    : {'args': '0'},
+    \ '-matchcase'  : {'args': '0'},
+    \ '-regex'      : {'args': '0'},
+    \ '-smartcase'  : {'args': '0'},
+    \ '-hidden'     : {'args': '0'},
+    \ '-encoding'   : {'args': '1'},
     \ '-A': {'fullname': '-after'},
     \ '-B': {'fullname': '-before'},
     \ '-C': {'fullname': '-context'},
@@ -291,9 +291,10 @@ func! s:ParseOptions(options_str) abort
             let opt  = s:option_list[opt.fullname]
         endif
 
-        if opt.args == 0
+        if opt.args == '0'
             let options[name] = 1
-        elseif opt.args == 1
+
+        elseif opt.args == '1'
             if tokens[i] =~# '^\d\+$'
                 let options[name] = str2nr(tokens[i])
             else
@@ -301,6 +302,19 @@ func! s:ParseOptions(options_str) abort
             endif
 
             let i += 1
+
+        elseif opt.args == '*'
+          if !has_key(options, name)
+            let options[name] = []
+          endif
+
+          if tokens[i] =~# '^\d\+$'
+            call add(options[name], str2nr(tokens[i]))
+          else
+            call add(options[name], tokens[i])
+          endif
+
+          let i += 1
         else
             let argv = []
             for j in range(opt.args)


### PR DESCRIPTION
I sometime need to exclude a number of file patterns from my search (e.g. `-G !*.log`, `-G !*.txt`).
With the current version of CtrlSF I can only exclude one.

This Pull Request introduce the possibility to introduce multiple `-G` flag.
