### PR TITLE
Searchwd #344

### DIFF
--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -426,21 +426,28 @@ func! s:OpenFileInWindow(file, lnum, col, mode, split) abort
         endif
     endif
 
+    let file_path = ''
+    if isabsolutepath(a:file)
+      let file_path = a:file
+    else
+      let file_path = g:ctrlsf_pwd . '/' . a:file
+    endif
+
     let target_winnr = ctrlsf#win#FindTargetWindow(a:file)
     if target_winnr == 0
-        exec 'silent split ' . fnameescape(a:file)
+        exec 'silent split ' . fnameescape(file_path)
     else
         exec target_winnr . 'wincmd w'
 
         if bufname('%') !=# a:file
             if a:split || (&modified && !&hidden)
                 if a:split == 2
-                    exec 'silent vertical split ' . fnameescape(a:file)
+                    exec 'silent vertical split ' . fnameescape(file_path)
                 else
-                    exec 'silent split ' . fnameescape(a:file)
+                    exec 'silent split ' . fnameescape(file_path)
                 endif
             else
-                exec 'silent edit ' . fnameescape(a:file)
+                exec 'silent edit ' . fnameescape(file_path)
             endif
         endif
     endif

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -493,13 +493,20 @@ endf
 func! s:PreviewFile(file, lnum, col, follow) abort
     call ctrlsf#preview#OpenPreviewWindow()
 
-    if !exists('b:ctrlsf_file') || empty(b:ctrlsf_file) || b:ctrlsf_file !=# a:file
-        let b:ctrlsf_file = a:file
+    let file_path = ''
+    if isabsolutepath(a:file)
+      let file_path = a:file
+    else
+      let file_path = g:ctrlsf_pwd . '/' . a:file
+    endif
 
-        call ctrlsf#buf#WriteFile(a:file)
+    if !exists('b:ctrlsf_file') || empty(b:ctrlsf_file) || b:ctrlsf_file !=# file_path
+        let b:ctrlsf_file = file_path
+
+        call ctrlsf#buf#WriteFile(file_path)
 
         " trigger filetypedetect (syntax highlight)
-        exec 'doau filetypedetect BufRead ' . fnameescape(a:file)
+        exec 'doau filetypedetect BufRead ' . fnameescape(file_path)
     endif
 
     call ctrlsf#win#MoveCursorCentral(a:lnum, a:col)

--- a/autoload/ctrlsf.vim
+++ b/autoload/ctrlsf.vim
@@ -32,6 +32,8 @@ func! s:ExecSearch(args, override = v:false) abort
         return -1
     endif
 
+    let g:ctrlsf_pwd = getcwd()
+
     call ctrlsf#profile#Sample("StartSearch")
     if g:ctrlsf_search_mode ==# 'sync'
         call s:DoSearchSync(a:args)

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -83,6 +83,7 @@ let s:backend_args_map = {
 " BuildCommand()
 "
 func! s:BuildCommand(args, for_shell) abort
+    let g:ctrlsf_pwd = getcwd()
     let tokens = []
     let runner = ctrlsf#backend#Runner()
 

--- a/autoload/ctrlsf/backend.vim
+++ b/autoload/ctrlsf/backend.vim
@@ -83,7 +83,6 @@ let s:backend_args_map = {
 " BuildCommand()
 "
 func! s:BuildCommand(args, for_shell) abort
-    let g:ctrlsf_pwd = getcwd()
     let tokens = []
     let runner = ctrlsf#backend#Runner()
 

--- a/autoload/ctrlsf/edit.vim
+++ b/autoload/ctrlsf/edit.vim
@@ -141,7 +141,12 @@ endf
 " s:SaveFile()
 "
 func! s:SaveFile(orig, modi) abort
-    let file = a:orig.filename
+    let file = ''
+    if isabsolutepath(a:orig.filename)
+      let file = a:orig.filename
+    else
+      let file = g:ctrlsf_pwd . '/' . a:orig.filename
+    endif
 
     try
         let buffer = readfile(file)


### PR DESCRIPTION
Dear CtrlSF,

Here is a pull request that solve issue #344 (make sure CtrlSF is not get lost when the working directory has changed since the original search request).

_Note: I have a plugin (vim-rooter) that change the working directory when visiting files._

According to your suggestion I have adapted the original pull request to support also the edition of the buffers.

Kind regards,
Vivian.